### PR TITLE
Removing the arguments.callee to support strict JS

### DIFF
--- a/src/subtitles-octopus.js
+++ b/src/subtitles-octopus.js
@@ -207,8 +207,8 @@ var SubtitlesOctopus = function (options) {
                 self.resize();
             }
             else {
-                self.video.addEventListener("loadedmetadata", function (e) {
-                    e.target.removeEventListener(e.type, arguments.callee);
+                self.video.addEventListener("loadedmetadata", function listener(e) {
+                    e.target.removeEventListener(e.type, listener);
                     self.resize();
                 }, false);
             }


### PR DESCRIPTION
This little change is necessary to work with scripts that have "use strict";.