### PR TITLE
Add ready event upon worker-init

### DIFF
--- a/src/post-worker.js
+++ b/src/post-worker.js
@@ -541,6 +541,9 @@ function onMessageFromMainEmscriptenThread(message) {
             self.libassMemoryLimit = message.data.libassMemoryLimit || self.libassMemoryLimit;
             self.libassGlyphLimit = message.data.libassGlyphLimit || 0;
             removeRunDependency('worker-init');
+            postMessage({
+                target: "ready",
+            });
             break;
         }
         case 'destroy':

--- a/src/subtitles-octopus.js
+++ b/src/subtitles-octopus.js
@@ -399,6 +399,9 @@ var SubtitlesOctopus = function (options) {
                 console.log(data.styles);
                 break;
             }
+            case 'ready': {
+                break;
+            }
             default:
                 throw 'what? ' + data.target;
         }


### PR DESCRIPTION
Upon upgrading from 2.1.1 to 4.0.0, the `onReady` event appears to no longer be fired upon initialization. While on 2.1.1, it seemed that the first even was a canvas message, even before loading sub files. However, it seems that there is no such event generated on initial load, so a ready post message at the end of the `worker-init` event to trigger the `onReady` handler.