### PR TITLE
Removed duplicate `timeupdate` event listener

### DIFF
--- a/src/subtitles-octopus.js
+++ b/src/subtitles-octopus.js
@@ -184,9 +184,6 @@ var SubtitlesOctopus = function (options) {
             self.video.addEventListener("ratechange", function () {
                 self.setRate(video.playbackRate);
             }, false);
-            self.video.addEventListener("timeupdate", function () {
-                self.setCurrentTime(video.currentTime + self.timeOffset);
-            }, false);
             self.video.addEventListener("waiting", function () {
                 self.setIsPaused(true, video.currentTime + self.timeOffset);
             }, false);


### PR DESCRIPTION
I remove duplicate `timeupdate` event listener. One has been added here:
https://github.com/libass/JavascriptSubtitlesOctopus/blob/8309002ed6948ee62eec57852690f9efbcaf258f/src/subtitles-octopus.js#L167-L170