### PR TITLE
Fix libass' sourceversion string

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -239,15 +239,16 @@ $(DIST_DIR)/lib/libfontconfig.a: $(DIST_DIR)/lib/libharfbuzz.a $(DIST_DIR)/lib/l
 
 # libass --
 
-build/lib/libass/configure: lib/libass
+build/lib/libass/configured: lib/libass
 	rm -rf build/lib/libass
-	cp -r lib/libass build/lib/libass
-	cd build/lib/libass && NOCONFIGURE=1 ./autogen.sh
+	cd lib/libass && NOCONFIGURE=1 ./autogen.sh
+	mkdir -p build/lib/libass
+	touch build/lib/libass/configured
 
-$(DIST_DIR)/lib/libass.a: $(DIST_DIR)/lib/libfontconfig.a $(DIST_DIR)/lib/libharfbuzz.a $(DIST_DIR)/lib/libexpat.a $(DIST_DIR)/lib/libfribidi.a $(DIST_DIR)/lib/libfreetype.a $(DIST_DIR)/lib/libbrotlidec.a build/lib/libass/configure
+$(DIST_DIR)/lib/libass.a: $(DIST_DIR)/lib/libfontconfig.a $(DIST_DIR)/lib/libharfbuzz.a $(DIST_DIR)/lib/libexpat.a $(DIST_DIR)/lib/libfribidi.a $(DIST_DIR)/lib/libfreetype.a $(DIST_DIR)/lib/libbrotlidec.a build/lib/libass/configured
 	cd build/lib/libass && \
 	EM_PKG_CONFIG_PATH=$(DIST_DIR)/lib/pkgconfig \
-	emconfigure ./configure \
+	emconfigure ../../../lib/libass/configure \
 		CFLAGS=" \
 		-s USE_PTHREADS=0 \
 		$(GLOBAL_CFLAGS) \

--- a/README.md
+++ b/README.md
@@ -152,13 +152,17 @@ To use, just run: `brotli subFile.ass` and use the .br result file with the subU
 
 Run `git clone --recursive https://github.com/libass/JavascriptSubtitlesOctopus.git`
 
-### Build with Docker
+### Build inside a Container
+#### Docker
 1) Install Docker
-2) `docker build -t libass/javascriptsubtitlesoctopus .`
-3) `docker run -it --rm -v ${PWD}:/code libass/javascriptsubtitlesoctopus:latest`
-4) Artifacts are in /dist/js
+2) `./run-docker-build.sh`
+3) Artifacts are in /dist/js
+#### Buildah
+1) Install Buildah and a suitable backend for `buildah run` like `crun` or `runc`
+2) `./run-buildah-build.sh`
+3) Artifacts are in /dist/js
 
-### Build without Docker
+### Build without Containers
 1) Install the dependency packages listed above
 2) `make`
     - If on macOS with libtool from brew, `LIBTOOLIZE=glibtoolize make`

--- a/run-buildah-build.sh
+++ b/run-buildah-build.sh
@@ -1,0 +1,18 @@
+#! /bin/sh
+set -e
+cd "$(dirname "$0")"
+
+. ./run-common.sh
+
+if [ "$#" -eq 0 ] ; then
+    cmd="make"
+else
+    cmd=""
+fi
+
+if [ "$FAST" -eq 0 ] ; then
+    buildah bud -t "$IMAGE" .
+    buildah rm "$CONTAINER" >/dev/null 2>&1 || :
+    buildah from --name "$CONTAINER" "$IMAGE":latest
+fi
+buildah run -t -v "${PWD}":/code "$CONTAINER" $cmd "$@"

--- a/run-common.sh
+++ b/run-common.sh
@@ -1,0 +1,27 @@
+usage() {
+    echo "$0 [-f] [-c con_name] [-i img_name] [commmand [command_args...]]"
+    echo "  -f: Skip building the container and reuse existing (\"fast\")"
+    echo "  -c: Name of the container to create/use;"
+    echo "      defaults to libass/javascriptsubtitlesoctopus-build"
+    echo "  -i: Name of the image to buld/use;"
+    echo "      defaults to libass/javascriptsubtitlesoctopus-build"
+    echo "If no command is given `make` without arguments will be executed"
+    exit 2
+}
+
+OPTIND=1
+CONTAINER="libass/javascriptsubtitlesoctopus-build"
+IMAGE="libass/javascriptsubtitlesoctopus-build"
+FAST=0
+while getopts "fc:s:" opt ; do
+    case "$opt" in
+        f) FAST=1 ;;
+        c) CONTAINER="$OPTARG" ;;
+        i) IMAGE="$OPTARG" ;;
+        *) usage ;;
+    esac
+done
+
+if [ "$OPTIND" -gt 1 ] ; then
+    shift $(( OPTIND - 1 ))
+fi

--- a/run-docker-build.sh
+++ b/run-docker-build.sh
@@ -1,5 +1,14 @@
 #! /bin/sh
 set -e
 cd "$(dirname "$0")"
-docker build -t libass/javascriptsubtitlesoctopus .
-docker run -it --rm -v "${PWD}":/code libass/javascriptsubtitlesoctopus:latest
+
+. ./run-common.sh
+
+if [ "$FAST" -eq 0 ] ; then
+    docker build -t "$IMAGE" .
+fi
+if [ "$#" -eq 0 ] ; then
+    docker run -it --rm -v "${PWD}":/code --name "$CONTAINER" "$IMAGE":latest
+else
+    docker run -it --rm -v "${PWD}":/code --name "$CONTAINER" "$IMAGE":latest "$@"
+fi


### PR DESCRIPTION
The relevant change here is to enable correctly setting the sourceversion string for the libass build; `run-buildah-build.sh` and `run-docker-build.sh`-cahnges are just for convenience and can be dropped if they are not liked. *(Admittedly the `run-docker-build.sh` change is untested, but seems simple enough)*.

In previous libass versions setting the sourceversion would partly fail because it didn't handle submodule correctly and treat it like a tarball instead. With recent libass setting the version would fail because the git command to determine the commit+info failed due to the link in the copied `.git` file being broken. By using a VPATH build, like it's already done for expat, we avoid this (and in both cases there are no patches to worry about).

As a future note: All our compiled subprojects support VPATH builds, if we either use eg `quilt` instead of plain `patch` to properly manage patches, or reset the submodules with `git reset --hard HEAD && git clean fdx` before reapplying patches when required, all subprojects could switch to VPATH builds.