### PR TITLE
[Jellyfin] Old browsers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 BASE_DIR:=$(dir $(realpath $(firstword $(MAKEFILE_LIST))))
 DIST_DIR:=$(BASE_DIR)dist/libraries
 
-GLOBAL_CFLAGS:=-O3
+GLOBAL_CFLAGS:=-O3 -s ENVIRONMENT=web,webview -s DOUBLE_MODE=0
 
 all: subtitleoctopus
 
@@ -306,6 +306,8 @@ EMCC_COMMON_ARGS = \
 	--preload-file assets/fonts.conf \
 	-s ALLOW_MEMORY_GROWTH=1 \
 	-s NO_FILESYSTEM=0 \
+	-s ENVIRONMENT=web,webview \
+	-s DOUBLE_MODE=0 \
 	--no-heap-copy \
 	-o $@
 	#--js-opts 0 -g4 \
@@ -334,6 +336,8 @@ dist/js/subtitles-octopus-worker-legacy.js: src/subtitles-octopus-worker.bc src/
 		--post-js src/post-worker.js \
 		-s WASM=0 \
 		-s LEGACY_VM_SUPPORT=1 \
+		-s MIN_CHROME_VERSION=27 \
+		-s MIN_SAFARI_VERSION=60005 \
 		$(EMCC_COMMON_ARGS)
 
 dist/js/subtitles-octopus.js: dist/license/all src/subtitles-octopus.js

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 BASE_DIR:=$(dir $(realpath $(firstword $(MAKEFILE_LIST))))
 DIST_DIR:=$(BASE_DIR)dist/libraries
 
-GLOBAL_CFLAGS:=-O3 -s ENVIRONMENT=web,webview -s DOUBLE_MODE=0
+GLOBAL_CFLAGS:=-O3 -s ENVIRONMENT=web,webview
 
 all: subtitleoctopus
 
@@ -306,8 +306,6 @@ EMCC_COMMON_ARGS = \
 	--preload-file assets/fonts.conf \
 	-s ALLOW_MEMORY_GROWTH=1 \
 	-s NO_FILESYSTEM=0 \
-	-s ENVIRONMENT=web,webview \
-	-s DOUBLE_MODE=0 \
 	--no-heap-copy \
 	-o $@
 	#--js-opts 0 -g4 \

--- a/src/post-worker.js
+++ b/src/post-worker.js
@@ -469,6 +469,14 @@ function messageResender() {
     }
 }
 
+function _applyKeys(input, output) {
+    var vargs = Object.keys(input);
+
+    for (var i = 0; i < vargs.length; i++) {
+        output[vargs[i]] = input[vargs[i]];
+    }
+}
+
 function onMessageFromMainEmscriptenThread(message) {
     if (!calledMain && !message.data.preMain) {
         if (!messageBuffer) {
@@ -562,11 +570,7 @@ function onMessageFromMainEmscriptenThread(message) {
             var event = message.data.event;
             var i = self.octObj.allocEvent();
             var evnt_ptr = self.octObj.track.get_events(i);
-            var vargs = Object.keys(event);
-
-            for (const varg of vargs) {
-                evnt_ptr[varg] = event[varg];
-            }
+            _applyKeys(event, evnt_ptr);
             break;
         case 'get-events':
             var events = [];
@@ -598,12 +602,7 @@ function onMessageFromMainEmscriptenThread(message) {
             var event = message.data.event;
             var i = message.data.index;
             var evnt_ptr = self.octObj.track.get_events(i);
-            
-            var vargs = Object.keys(event);
-
-            for (const varg of vargs) {
-                evnt_ptr[varg] = event[varg];
-            }
+            _applyKeys(event, evnt_ptr);
             break;
         case 'remove-event':
             var i = message.data.index;
@@ -613,11 +612,7 @@ function onMessageFromMainEmscriptenThread(message) {
             var style = message.data.style;
             var i = self.octObj.allocStyle();
             var styl_ptr = self.octObj.track.get_styles(i);
-            var vargs = Object.keys(style);
-
-            for (const varg of vargs) {
-                styl_ptr[varg] = style[varg];
-            }
+            _applyKeys(style, styl_ptr);
             break;
         case 'get-styles':
             var styles = [];
@@ -663,11 +658,7 @@ function onMessageFromMainEmscriptenThread(message) {
             var style = message.data.style;
             var i = message.data.index;
             var styl_ptr = self.octObj.track.get_styles(i);
-            var vargs = Object.keys(style);
-
-            for (const varg of vargs) {
-                styl_ptr[varg] = style[varg];
-            }
+            _applyKeys(style, styl_ptr);
             break;
         case 'remove-style':
             var i = message.data.index;

--- a/src/pre-worker.js
+++ b/src/pre-worker.js
@@ -1,3 +1,12 @@
+if (!String.prototype.startsWith) {
+    String.prototype.startsWith = function (search, pos) {
+        if (pos === undefined) {
+            pos = 0;
+        }
+        return this.substring(pos, search.length) === search;
+    };
+}
+
 if (!String.prototype.endsWith) {
 	String.prototype.endsWith = function(search, this_len) {
 		if (this_len === undefined || this_len > this.length) {
@@ -7,6 +16,12 @@ if (!String.prototype.endsWith) {
 	};
 }
 
+if (!String.prototype.includes) {
+    String.prototype.includes = function (search, pos) {
+        return this.indexOf(search, pos) !== -1;
+    };
+}
+
 if (!Uint8Array.prototype.slice) {
     Object.defineProperty(Uint8Array.prototype, 'slice', {
         value: function (begin, end)
@@ -14,6 +29,24 @@ if (!Uint8Array.prototype.slice) {
                 return new Uint8Array(this.subarray(begin, end));
             }
     });
+}
+
+if (!Int16Array.from) {
+    // Doesn't work for String
+    Int16Array.from = function (source) {
+        var arr = new Int16Array(source.length);
+        arr.set(source, 0);
+        return arr;
+    };
+}
+
+if (!Int32Array.from) {
+    // Doesn't work for String
+    Int32Array.from = function (source) {
+        var arr = new Int32Array(source.length);
+        arr.set(source, 0);
+        return arr;
+    };
 }
 
 

--- a/src/pre-worker.js
+++ b/src/pre-worker.js
@@ -7,6 +7,16 @@ if (!String.prototype.endsWith) {
 	};
 }
 
+if (!Uint8Array.prototype.slice) {
+    Object.defineProperty(Uint8Array.prototype, 'slice', {
+        value: function (begin, end)
+            {
+                return new Uint8Array(this.subarray(begin, end));
+            }
+    });
+}
+
+
 var hasNativeConsole = typeof console !== "undefined";
 
 // implement console methods if they're missing


### PR DESCRIPTION
This PR improves compatibility with older browsers.
Jellyfin is focused on supporting webOS 1.2 and Tizen 2.3, which use ancient web engines (WebKit).

I cherry-picked related commits, skipping merge-commits.

<details>
<summary>List of commits</summary>

82822b25340c2c3bd557710bf9e5ac7ef39af8de
64445220b42d1111eaafd7279afe857904efdef9
9299074ee500ad1c14ee8daac4fac7511524c9c2
`Merge pull request #15 from JustAMan/update-build`
other commits are new
</details>
