### PR TITLE
Fix blend render after seek

### DIFF
--- a/src/SubtitleOctopus.cpp
+++ b/src/SubtitleOctopus.cpp
@@ -233,10 +233,11 @@ public:
 
     RenderBlendResult* renderBlend(double tm, int force) {
         m_blendResult.blend_time = 0.0;
+        m_blendResult.image = NULL;
 
         ASS_Image *img = ass_render_frame(ass_renderer, track, (int)(tm * 1000), &m_blendResult.changed);
         if (img == NULL || (m_blendResult.changed == 0 && !force)) {
-            return NULL;
+            return &m_blendResult;
         }
 
         double start_blend_time = emscripten_get_now();
@@ -259,7 +260,7 @@ public:
         float* buf = (float*)buffer_resize(&m_blend, sizeof(float) * width * height * 4, 0);
         if (buf == NULL) {
             printf("libass: error: cannot allocate buffer for blending");
-            return NULL;
+            return &m_blendResult;
         }
         memset(buf, 0, sizeof(float) * width * height * 4);
 

--- a/src/post-worker.js
+++ b/src/post-worker.js
@@ -197,20 +197,24 @@ self.blendRender = function (force) {
     var startTime = performance.now();
 
     var renderResult = self.octObj.renderBlend(self.getCurrentTime() + self.delay, force);
-    var blendTime = Module.getValue(self.blendTime, 'double');
-    if (renderResult && (renderResult.changed != 0 || force)) {
-        // make a copy, as we should free the memory so subsequent calls can utilize it
-        var result = new Uint8Array(HEAPU8.subarray(renderResult.image, renderResult.image + renderResult.dest_width * renderResult.dest_height * 4));
+    if (renderResult.changed != 0 || force) {
+        var canvases = [];
+        var buffers = [];
 
-        var canvases = [{w: renderResult.dest_width, h: renderResult.dest_height, x: renderResult.dest_x, y: renderResult.dest_y, buffer: result.buffer}];
-        var buffers = [result.buffer];
+        if (renderResult.image) {
+            // make a copy, as we should free the memory so subsequent calls can utilize it
+            var result = new Uint8Array(HEAPU8.subarray(renderResult.image, renderResult.image + renderResult.dest_width * renderResult.dest_height * 4));
+
+            canvases = [{w: renderResult.dest_width, h: renderResult.dest_height, x: renderResult.dest_x, y: renderResult.dest_y, buffer: result.buffer}];
+            buffers = [result.buffer];
+        }
 
         postMessage({
             target: 'canvas',
             op: 'renderCanvas',
             time: Date.now(),
             spentTime: performance.now() - startTime,
-            blendTime: blendTime,
+            blendTime: renderResult.blend_time,
             canvases: canvases
         }, buffers);
     }


### PR DESCRIPTION
Blend render doesn't redraw the frame if you seek on an "empty" frame - the previous image remains on the screen.

**Steps To Reproduce**
1. Use `blend` render mode (`blendRender: true`).
2. Start a video with subtitles that doesn't start at the beginning.
3. Wait for the subtitles to appear.
3. Seek on an "empty" frame (at the beginning or any other position without subtitles).
4. The subtitles don't change to blank.
