### PR TITLE
Legacy Brotli

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,6 +70,7 @@ $(DIST_DIR)/lib/libexpat.a: build/lib/expat/configured
 	emmake make install
 
 build/lib/brotli/js/decode.js: build/lib/brotli/configured
+build/lib/brotli/js/polyfill.js: build/lib/brotli/configured
 build/lib/brotli/configured: lib/brotli $(wildcard $(BASE_DIR)build/patches/brotli/*.patch)
 	rm -rf build/lib/brotli
 	cp -r lib/brotli build/lib/brotli
@@ -325,10 +326,11 @@ dist/js/subtitles-octopus-worker.js: src/subtitles-octopus-worker.bc src/pre-wor
 		-s WASM=1 \
 		$(EMCC_COMMON_ARGS)
 
-dist/js/subtitles-octopus-worker-legacy.js: src/subtitles-octopus-worker.bc src/polyfill.js src/pre-worker.js src/SubOctpInterface.js src/post-worker.js build/lib/brotli/js/decode.js
+dist/js/subtitles-octopus-worker-legacy.js: src/subtitles-octopus-worker.bc src/polyfill.js src/pre-worker.js src/SubOctpInterface.js src/post-worker.js build/lib/brotli/js/decode.js build/lib/brotli/js/polyfill.js
 	mkdir -p dist/js
 	emcc src/subtitles-octopus-worker.bc $(OCTP_DEPS) \
 		--pre-js src/polyfill.js \
+		--pre-js build/lib/brotli/js/polyfill.js \
 		--pre-js src/pre-worker.js \
 		--pre-js build/lib/brotli/js/decode.js \
 		--post-js src/SubOctpInterface.js \

--- a/Makefile
+++ b/Makefile
@@ -325,9 +325,10 @@ dist/js/subtitles-octopus-worker.js: src/subtitles-octopus-worker.bc src/pre-wor
 		-s WASM=1 \
 		$(EMCC_COMMON_ARGS)
 
-dist/js/subtitles-octopus-worker-legacy.js: src/subtitles-octopus-worker.bc src/pre-worker.js src/SubOctpInterface.js src/post-worker.js build/lib/brotli/js/decode.js
+dist/js/subtitles-octopus-worker-legacy.js: src/subtitles-octopus-worker.bc src/polyfill.js src/pre-worker.js src/SubOctpInterface.js src/post-worker.js build/lib/brotli/js/decode.js
 	mkdir -p dist/js
 	emcc src/subtitles-octopus-worker.bc $(OCTP_DEPS) \
+		--pre-js src/polyfill.js \
 		--pre-js src/pre-worker.js \
 		--pre-js build/lib/brotli/js/decode.js \
 		--post-js src/SubOctpInterface.js \

--- a/src/polyfill.js
+++ b/src/polyfill.js
@@ -22,6 +22,33 @@ if (!String.prototype.includes) {
     };
 }
 
+if (!ArrayBuffer.isView) {
+    var typedArrays = [
+        Int8Array,
+        Uint8Array,
+        Uint8ClampedArray,
+        Int16Array,
+        Uint16Array,
+        Int32Array,
+        Uint32Array,
+        Float32Array,
+        Float64Array
+    ];
+
+    ArrayBuffer.isView = function (obj) {
+        return obj && obj.constructor && typedArrays.indexOf(obj.constructor) !== -1;
+    };
+}
+
+if (!Int8Array.prototype.slice) {
+    Object.defineProperty(Int8Array.prototype, 'slice', {
+        value: function (begin, end)
+            {
+                return new Int8Array(this.subarray(begin, end));
+            }
+    });
+}
+
 if (!Uint8Array.prototype.slice) {
     Object.defineProperty(Uint8Array.prototype, 'slice', {
         value: function (begin, end)

--- a/src/polyfill.js
+++ b/src/polyfill.js
@@ -1,0 +1,67 @@
+if (!String.prototype.startsWith) {
+    String.prototype.startsWith = function (search, pos) {
+        if (pos === undefined) {
+            pos = 0;
+        }
+        return this.substring(pos, search.length) === search;
+    };
+}
+
+if (!String.prototype.endsWith) {
+    String.prototype.endsWith = function (search, this_len) {
+        if (this_len === undefined || this_len > this.length) {
+            this_len = this.length;
+        }
+        return this.substring(this_len - search.length, this_len) === search;
+    };
+}
+
+if (!String.prototype.includes) {
+    String.prototype.includes = function (search, pos) {
+        return this.indexOf(search, pos) !== -1;
+    };
+}
+
+if (!Uint8Array.prototype.slice) {
+    Object.defineProperty(Uint8Array.prototype, 'slice', {
+        value: function (begin, end)
+            {
+                return new Uint8Array(this.subarray(begin, end));
+            }
+    });
+}
+
+if (!Int16Array.from) {
+    // Doesn't work for String
+    Int16Array.from = function (source) {
+        var arr = new Int16Array(source.length);
+        arr.set(source, 0);
+        return arr;
+    };
+}
+
+if (!Int32Array.from) {
+    // Doesn't work for String
+    Int32Array.from = function (source) {
+        var arr = new Int32Array(source.length);
+        arr.set(source, 0);
+        return arr;
+    };
+}
+
+// performance.now() polyfill
+if ("performance" in self === false) {
+    self.performance = {};
+}
+Date.now = (Date.now || function () {
+    return new Date().getTime();
+});
+if ("now" in self.performance === false) {
+    var nowOffset = Date.now();
+    if (performance.timing && performance.timing.navigationStart) {
+        nowOffset = performance.timing.navigationStart
+    }
+    self.performance.now = function now() {
+        return Date.now() - nowOffset;
+    }
+}

--- a/src/post-worker.js
+++ b/src/post-worker.js
@@ -103,7 +103,7 @@ self.freeTrack = function () {
  */
 self.setTrackByUrl = function (url) {
     var content = "";
-    if (url.endsWith(".br")) {
+    if (isBrotliFile(url)) {
         content = Module["BrotliDecode"](readBinary(url))
     } else {
         content = read_(url);

--- a/src/pre-worker.js
+++ b/src/pre-worker.js
@@ -84,6 +84,22 @@ function makeCustomConsole() {
     return console;
 }
 
+/**
+ * Test the subtitle file for Brotli compression.
+ * @param {!string} url the URL of the subtitle file.
+ * @returns {boolean} Brotli compression found or not.
+ */
+function isBrotliFile(url) {
+    // Search for parameters
+    var len = url.indexOf("?");
+
+    if (len === -1) {
+        len = url.length;
+    }
+
+    return url.endsWith(".br", len);
+}
+
 Module = Module || {};
 
 Module["preRun"] = Module["preRun"] || [];
@@ -96,7 +112,7 @@ Module["preRun"].push(function () {
 
     if (!self.subContent) {
         // We can use sync xhr cause we're inside Web Worker
-        if (self.subUrl.endsWith(".br")) {
+        if (isBrotliFile(self.subUrl)) {
             self.subContent = Module["BrotliDecode"](readBinary(self.subUrl))
         } else {
             self.subContent = read_(self.subUrl);

--- a/src/pre-worker.js
+++ b/src/pre-worker.js
@@ -1,55 +1,3 @@
-if (!String.prototype.startsWith) {
-    String.prototype.startsWith = function (search, pos) {
-        if (pos === undefined) {
-            pos = 0;
-        }
-        return this.substring(pos, search.length) === search;
-    };
-}
-
-if (!String.prototype.endsWith) {
-	String.prototype.endsWith = function(search, this_len) {
-		if (this_len === undefined || this_len > this.length) {
-			this_len = this.length;
-		}
-		return this.substring(this_len - search.length, this_len) === search;
-	};
-}
-
-if (!String.prototype.includes) {
-    String.prototype.includes = function (search, pos) {
-        return this.indexOf(search, pos) !== -1;
-    };
-}
-
-if (!Uint8Array.prototype.slice) {
-    Object.defineProperty(Uint8Array.prototype, 'slice', {
-        value: function (begin, end)
-            {
-                return new Uint8Array(this.subarray(begin, end));
-            }
-    });
-}
-
-if (!Int16Array.from) {
-    // Doesn't work for String
-    Int16Array.from = function (source) {
-        var arr = new Int16Array(source.length);
-        arr.set(source, 0);
-        return arr;
-    };
-}
-
-if (!Int32Array.from) {
-    // Doesn't work for String
-    Int32Array.from = function (source) {
-        var arr = new Int32Array(source.length);
-        arr.set(source, 0);
-        return arr;
-    };
-}
-
-
 var hasNativeConsole = typeof console !== "undefined";
 
 // implement console methods if they're missing
@@ -199,21 +147,4 @@ if (!hasNativeConsole) {
             if (typeof dump === 'function') dump('error: ' + x + '\n');
         },
     };
-}
-
-// performance.now() polyfill
-if ("performance" in self === false) {
-    self.performance = {};
-}
-Date.now = (Date.now || function () {
-    return new Date().getTime();
-});
-if ("now" in self.performance === false) {
-    var nowOffset = Date.now();
-    if (performance.timing && performance.timing.navigationStart) {
-        nowOffset = performance.timing.navigationStart
-    }
-    self.performance.now = function now() {
-        return Date.now() - nowOffset;
-    }
 }


### PR DESCRIPTION
1. A bunch of polyfills need to be added to support Brotli compression in legacy browsers.
Some of them (marked `From brotli`) are from https://github.com/google/brotli/blob/master/js/polyfill.js So they can be added by this file passed in `emcc`.
At the same time, if something changes in Brotli polyfills, it may affect JSO. For example, there is no `Int8Array.slice` in the version currently used by JSO, but there is in the latest recent.
Therefore, it is probably better to rely on Emscripten polyfills and explicitly added JSO polyfills.

2. URLs can contain params. For example, in Jellyfin the URL looks like `/Videos/{1}/{2]/Subtitles/{3}/{4}/Stream.ass?api_key={5}`.
_Jellyfin doesn't support Brotli compressed subtitles yet, but maybe someday._
_If you want, I can extract this part in a separate PR._

Tested in webOS 1.2 emulator with Brotli subtitles from `gh-pages` branch.

**Some thoughts**
Maybe extract polyfills in `polyfills.js` and add them only to the legacy worker?
