### PR TITLE
Fix Fontconfig cache not working

### DIFF
--- a/run-common.sh
+++ b/run-common.sh
@@ -2,7 +2,7 @@ usage() {
     echo "$0 [-f] [-c con_name] [-i img_name] [commmand [command_args...]]"
     echo "  -f: Skip building the container and reuse existing (\"fast\")"
     echo "  -c: Name of the container to create/use;"
-    echo "      defaults to libass/javascriptsubtitlesoctopus-build"
+    echo "      defaults to libass_javascriptsubtitlesoctopus-build"
     echo "  -i: Name of the image to buld/use;"
     echo "      defaults to libass/javascriptsubtitlesoctopus-build"
     echo "If no command is given `make` without arguments will be executed"
@@ -10,7 +10,7 @@ usage() {
 }
 
 OPTIND=1
-CONTAINER="libass/javascriptsubtitlesoctopus-build"
+CONTAINER="libass_javascriptsubtitlesoctopus-build"
 IMAGE="libass/javascriptsubtitlesoctopus-build"
 FAST=0
 while getopts "fc:s:" opt ; do

--- a/src/pre-worker.js
+++ b/src/pre-worker.js
@@ -92,6 +92,7 @@ Module["preRun"].push(function () {
     var i;
 
     Module["FS_createPath"]("/", "fonts", true, true);
+    Module["FS_createPath"]("/", "fontconfig", true, true);
 
     if (!self.subContent) {
         // We can use sync xhr cause we're inside Web Worker


### PR DESCRIPTION
Fix an error when starting JSO, there is no directory for font cache.
Also fix run-docker-build.sh not working because of invalid container name