### PR TITLE
(VREW-3081) Replace libass/libass with v6x/libass.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "lib/libass"]
 	path = lib/libass
-	url = https://github.com/libass/libass.git
+	url = https://github.com/v6x/libass.git
 	ignore = dirty
 [submodule "lib/fribidi"]
 	path = lib/fribidi

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "libass-wasm",
-  "version": "4.0.0",
+  "name": "@voyagerx/libass-wasm",
+  "version": "4.0.1",
   "description": "libass Subtitle Renderer and Parser library for browsers",
   "main": "dist/js/subtitles-octopus.js",
   "files": [
@@ -13,7 +13,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Dador/JavascriptSubtitlesOctopus.git"
+    "url": "git+https://github.com/v6x/JavascriptSubtitlesOctopus.git"
   },
   "keywords": [
     "libass",
@@ -24,7 +24,7 @@
   "author": "TFSThiagoBR98, Dador",
   "license": "LGPL-2.1-or-later AND (FTL OR GPL-2.0-or-later) AND MIT AND MIT-Modern-Variant AND ISC AND NTP AND Zlib AND BSL-1.0",
   "bugs": {
-    "url": "https://github.com/Dador/JavascriptSubtitlesOctopus/issues"
+    "url": "https://github.com/v6x/JavascriptSubtitlesOctopus/issues"
   },
-  "homepage": "https://dador.github.io/JavascriptSubtitlesOctopus/"
+  "homepage": "https://github.com/v6x/JavascriptSubtitlesOctopus"
 }


### PR DESCRIPTION
This patch replaces [libass/libass](https://github.com/libass/libass) with [v6x/libass](https://github.com/v6x/libass).