### PR TITLE
[Jellyfin] Rework buffer into C++ class

### DIFF
--- a/src/SubtitleOctopus.cpp
+++ b/src/SubtitleOctopus.cpp
@@ -21,11 +21,11 @@ int log_level = 3;
 
 typedef struct {
     void *buffer;
-    int size;
-    int lessen_counter;
+    size_t size;
+    size_t lessen_counter;
 } buffer_t;
 
-void* buffer_resize(buffer_t *buf, int new_size, int keep_content) {
+void* buffer_resize(buffer_t *buf, size_t new_size, int keep_content) {
     if (buf->size >= new_size) {
         if (buf->size >= 1.3 * new_size) {
             // big reduction request
@@ -56,7 +56,7 @@ void* buffer_resize(buffer_t *buf, int new_size, int keep_content) {
 
 void buffer_init(buffer_t *buf) {
     buf->buffer = NULL;
-    buf->size = -1;
+    buf->size = 0;
     buf->lessen_counter = 0;
 }
 

--- a/src/SubtitleOctopus.cpp
+++ b/src/SubtitleOctopus.cpp
@@ -268,12 +268,13 @@ public:
         }
 
         // make float buffer for blending
-        float* buf = (float*)buffer_resize(&m_blend, sizeof(float) * width * height * 4, 0);
+        const size_t buffer_size = width * height * 4 * sizeof(float);
+        float* buf = (float*)buffer_resize(&m_blend, buffer_size, 0);
         if (buf == NULL) {
             fprintf(stderr, "jso: cannot allocate buffer for blending\n");
             return &m_blendResult;
         }
-        memset(buf, 0, sizeof(float) * width * height * 4);
+        memset(buf, 0, buffer_size);
 
         // blend things in
         for (cur = img; cur != NULL; cur = cur->next) {

--- a/src/SubtitleOctopus.cpp
+++ b/src/SubtitleOctopus.cpp
@@ -355,4 +355,6 @@ private:
 
 int main(int argc, char *argv[]) { return 0; }
 
+#ifdef __EMSCRIPTEN__
 #include "./SubOctpInterface.cpp"
+#endif


### PR DESCRIPTION
Cherry-picked from: https://github.com/jellyfin/JavascriptSubtitlesOctopus/commit/6d3a5c731f52ea84282e40bed3014ef95220146a
Cherry-picked from (part of): https://github.com/jellyfin/JavascriptSubtitlesOctopus/commit/0cc2bf8556f4936a483c8a027e0b2ff2774ed9d1

This is the only thing I can extract with such strict requirements in your repo. :neutral_face:
_* and my own principles of porting the results of teamwork from the fork._