### PR TITLE
Fix blend render returning empty result

### DIFF
--- a/src/SubtitleOctopus.cpp
+++ b/src/SubtitleOctopus.cpp
@@ -247,6 +247,7 @@ public:
         int max_x = img->dst_x + img->w - 1, max_y = img->dst_y + img->h - 1;
         ASS_Image *cur;
         for (cur = img->next; cur != NULL; cur = cur->next) {
+            if (cur->w == 0 || cur->h == 0) continue; // skip empty images
             if (cur->dst_x < min_x) min_x = cur->dst_x;
             if (cur->dst_y < min_y) min_y = cur->dst_y;
             int right = cur->dst_x + cur->w - 1;
@@ -255,8 +256,14 @@ public:
             if (bottom > max_y) max_y = bottom;
         }
 
-        // make float buffer for blending
         int width = max_x - min_x + 1, height = max_y - min_y + 1;
+
+        if (width == 0 || height == 0) {
+            // all images are empty
+            return &m_blendResult;
+        }
+
+        // make float buffer for blending
         float* buf = (float*)buffer_resize(&m_blend, sizeof(float) * width * height * 4, 0);
         if (buf == NULL) {
             printf("libass: error: cannot allocate buffer for blending");


### PR DESCRIPTION
libass may return empty images, and 'blendResult' may become invalid (with zero height), leading to a runtime error when displaying.
Noticed on 'Railgun S Karaoke Test' ~26.38s (after the first verse) with `dropAllAnimations` enabled.

Would checking `<= 0` be better, since `width` and `height` are `int`?
They probably can't be negative by design, but... :thinking: 

This seems to be reproduced with `wasm-blend` on [empty_image.ass.txt](https://github.com/libass/JavascriptSubtitlesOctopus/files/7998336/empty_image.ass.txt)
