### PR TITLE
Framebuffer overflow protection

### DIFF
--- a/src/SubtitleOctopus.cpp
+++ b/src/SubtitleOctopus.cpp
@@ -21,11 +21,11 @@ int log_level = 3;
 
 typedef struct {
     void *buffer;
-    int size;
-    int lessen_counter;
+    size_t size;
+    size_t lessen_counter;
 } buffer_t;
 
-void* buffer_resize(buffer_t *buf, int new_size, int keep_content) {
+void* buffer_resize(buffer_t *buf, size_t new_size, int keep_content) {
     if (buf->size >= new_size) {
         if (buf->size >= 1.3 * new_size) {
             // big reduction request
@@ -56,7 +56,7 @@ void* buffer_resize(buffer_t *buf, int new_size, int keep_content) {
 
 void buffer_init(buffer_t *buf) {
     buf->buffer = NULL;
-    buf->size = -1;
+    buf->size = 0;
     buf->lessen_counter = 0;
 }
 

--- a/src/SubtitleOctopus.cpp
+++ b/src/SubtitleOctopus.cpp
@@ -268,12 +268,13 @@ public:
         }
 
         // make float buffer for blending
-        float* buf = (float*)buffer_resize(&m_blend, sizeof(float) * width * height * 4, 0);
+        const size_t buffer_size = width * height * 4 * sizeof(float);
+        float* buf = (float*)buffer_resize(&m_blend, buffer_size, 0);
         if (buf == NULL) {
             fprintf(stderr, "jso: cannot allocate buffer for blending\n");
             return &m_blendResult;
         }
-        memset(buf, 0, sizeof(float) * width * height * 4);
+        memset(buf, 0, buffer_size);
 
         // blend things in
         for (cur = img; cur != NULL; cur = cur->next) {

--- a/src/SubtitleOctopus.cpp
+++ b/src/SubtitleOctopus.cpp
@@ -19,6 +19,11 @@
 
 int log_level = 3;
 
+// maximum frame buffer width (8K resolution)
+const size_t FRAMEBUFFER_MAX_WIDTH = 7680;
+// maximum frame buffer height (8K resolution)
+const size_t FRAMEBUFFER_MAX_HEIGHT = 4320;
+
 typedef struct {
     void *buffer;
     size_t size;
@@ -163,6 +168,13 @@ public:
 
     /* CANVAS */
     void resizeCanvas(int frame_w, int frame_h) {
+        if (frame_w > FRAMEBUFFER_MAX_WIDTH || frame_h > FRAMEBUFFER_MAX_HEIGHT) {
+            fprintf(stderr, "jso: canvas is oversized - %dx%d\n", frame_w, frame_h);
+            if (frame_w > FRAMEBUFFER_MAX_WIDTH) frame_w = FRAMEBUFFER_MAX_WIDTH;
+            if (frame_h > FRAMEBUFFER_MAX_HEIGHT) frame_h = FRAMEBUFFER_MAX_HEIGHT;
+            printf("jso: canvas is trimmed to %dx%d\n", frame_w, frame_h);
+        }
+
         ass_set_frame_size(ass_renderer, frame_w, frame_h);
         canvas_h = frame_h;
         canvas_w = frame_w;


### PR DESCRIPTION
Quick fix for https://github.com/libass/JavascriptSubtitlesOctopus/pull/120#discussion_r795268373
> Pre-existing issue (so new commit to fix), but this line has potentially a big issue: Afaict there's no prior checks for this and the multiplications for the `new_size` parameter can overflow the bounds of `int`, which is in itself already undefined behaviour, but if your lucky only truncates. Worse though, the buffer is later accessed by values recalculated from `width` and `height`, so if the multiplication here overflowed (and the overflow itself doesn't blow up), an out-of-bound write happens either blowing up or corrupting some other memory. Is `ReusableBuffer` ever used for something else than an float-RGBA canvas alter down the line in jellyfin-patches? If not it's probably best to pass `width`, `height` and `member_size` as separate `size_t`-type values to the resize function and do all the overflow checking inside the function.

~Personally, I don't like re-calculation of size at this line `memset(buf, 0, sizeof(float) * width * height * 4);`~
_Stored in a variable before calling `buffer_resize`._

~I am thinking about:~
```cpp
typedef struct {
    float *buffer;
    size_t size;        // save the new_size
    size_t capacity;    // as the size member before
    size_t lessen_counter;
} buffer_t;
```
_Storing the `size` is not suitable for `ReusableBuffer`. But it is fine for  `FrameBuffer`._
