### PR TITLE
Various minor fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ thread, instead will run Async, so if the function createImageBitmap fail, it
 will not stop the rendering process at all and may cause some bitmap loss or
 simply will not draw anything in canvas, mostly on low end devices.
 
-**WARNING: Experimental, not stable and not working in Safari**
+**WARNING: Experimental, not stable and not working in some browsers**
 
 
 ### Brotli Compressed Subtitles

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-[![Actions Status](https://github.com/libass/JavascriptSubtitlesOctopus/workflows/Emscripten/badge.svg)](https://github.com/libass/JavascriptSubtitlesOctopus/actions)
+[![Actions Status](https://github.com/libass/JavascriptSubtitlesOctopus/actions/workflows/emscripten.yml/badge.svg)](https://github.com/libass/JavascriptSubtitlesOctopus/actions/workflows/emscripten.yml?query=branch%3Amaster+event%3Apush)
+
 
 SubtitlesOctopus displays subtitles in .ass format and easily integrates with HTML5 videos.
 Since it uses [libass](https://github.com/libass/libass), SubtitlesOctopus supports most

--- a/src/SubtitleOctopus.cpp
+++ b/src/SubtitleOctopus.cpp
@@ -294,13 +294,13 @@ public:
                 {
                     float pix_alpha = bitmap[bitmap_offset + x] * normalized_a / 255.0;
                     float inv_alpha = 1.0 - pix_alpha;
-                    
+
                     int buf_coord = (buf_line_coord + curx + x) << 2;
                     float *buf_r = buf + buf_coord;
                     float *buf_g = buf + buf_coord + 1;
                     float *buf_b = buf + buf_coord + 2;
                     float *buf_a = buf + buf_coord + 3;
-                    
+
                     // do the compositing, pre-multiply image RGB with alpha for current pixel
                     *buf_a = pix_alpha + *buf_a * inv_alpha;
                     *buf_r = r * pix_alpha + *buf_r * inv_alpha;
@@ -332,7 +332,7 @@ public:
                 result[buf_line_coord + x] = pixel;
             }
         }
-        
+
         // return the thing
         m_blendResult.dest_x = min_x;
         m_blendResult.dest_y = min_y;

--- a/src/SubtitleOctopus.cpp
+++ b/src/SubtitleOctopus.cpp
@@ -189,7 +189,7 @@ public:
         ass_set_margins(ass_renderer, top, bottom, left, right);
     }
 
-    int getEventCount() {
+    int getEventCount() const {
         return track->n_events;
     }
 
@@ -201,11 +201,11 @@ public:
         ass_free_event(track, eid);
     }
 
-    int getStyleCount() {
+    int getStyleCount() const {
         return track->n_styles;
     }
 
-    int getStyleByName(const char* name) {
+    int getStyleByName(const char* name) const {
         for (int n = 0; n < track->n_styles; n++) {
             if (track->styles[n].Name && strcmp(track->styles[n].Name, name) == 0)
                 return n;

--- a/src/SubtitleOctopus.cpp
+++ b/src/SubtitleOctopus.cpp
@@ -77,7 +77,7 @@ const float MAX_UINT8_CAST = 255.9 / 255;
 
 #define CLAMP_UINT8(value) ((value > MIN_UINT8_CAST) ? ((value < MAX_UINT8_CAST) ? (int)(value * 255) : 255) : 0)
 
-typedef struct {
+typedef struct RenderBlendResult {
 public:
     int changed;
     double blend_time;

--- a/src/post-worker.js
+++ b/src/post-worker.js
@@ -541,6 +541,14 @@ function onMessageFromMainEmscriptenThread(message) {
             self.subContent = message.data.subContent;
             self.fontFiles = message.data.fonts;
             self.renderMode = message.data.renderMode;
+            // Force fallback if engine does not support 'lossy' mode.
+            // We only use createImageBitmap in the worker and historic WebKit versions supported
+            // the API in the normal but not the worker scope, so we can't check this earlier.
+            if (self.renderMode == 'lossy' && typeof createImageBitmap === 'undefined') {
+                self.renderMode = 'wasm-blend';
+                console.error("'createImageBitmap' needed for 'lossy' unsupported. Falling back to default!");
+            }
+
             self.availableFonts = message.data.availableFonts;
             self.debug = message.data.debug;
             if (!hasNativeConsole && self.debug) {

--- a/src/post-worker.js
+++ b/src/post-worker.js
@@ -21,11 +21,11 @@ self.fontId = 0;
  */
 self.writeFontToFS = function(font) {
     font = font.trim().toLowerCase();
-    
+
     if (font.startsWith("@")) {
         font = font.substr(1);
     }
-    
+
     if (self.fontMap_.hasOwnProperty(font)) return;
 
     self.fontMap_[font] = true;
@@ -33,7 +33,7 @@ self.writeFontToFS = function(font) {
     if (!self.availableFonts.hasOwnProperty(font)) return;
     var content = readBinary(self.availableFonts[font]);
 
-    Module["FS"].writeFile('/fonts/font' + (self.fontId++) + '-' + self.availableFonts[font].split('/').pop(), content, { 
+    Module["FS"].writeFile('/fonts/font' + (self.fontId++) + '-' + self.availableFonts[font].split('/').pop(), content, {
         encoding: 'binary'
     });
 };
@@ -54,7 +54,7 @@ self.writeAvailableFontsToFS = function(content) {
             }
         }
     }
-    
+
     var regex = /\\fn([^\\}]*?)[\\}]/g;
     var matches;
     while (matches = regex.exec(self.subContent)) {
@@ -144,7 +144,7 @@ self.setCurrentTime = function (currentTime) {
         }
         else {
             self.getRenderMethod()();
-            
+
             // Give onmessage chance to receive all queued messages
             setTimeout(function () {
                 self.nextIsRaf = false;

--- a/src/post-worker.js
+++ b/src/post-worker.js
@@ -70,6 +70,7 @@ self.getRenderMethod = function () {
             return self.render;
         default:
             console.error('Unrecognised renderMode, falling back to default!');
+            self.renderMode = 'wasm-blend';
             // fallthrough
         case 'wasm-blend':
             return self.blendRender;


### PR DESCRIPTION
As the commit messages notes, the original, backported check for `createImageBitmap` was performed twice once in the main JS interface and once in the worker; unfortunately the commit message doesn't explain why. After a quick search I didn't spot any indication that the API’s availability can differ between worker and non-worker, but I'm not too familiar with the JS-APIs.

Otherwise this should be fairly innocuous.