### PR TITLE
Add options for bounding and scaling the rendering canvas

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,11 @@ When creating an instance of SubtitleOctopus, you can set the following options:
                        (Default: `0` - no limit)
 - `libassGlyphLimit`: libass glyph cache memory limit in MiB (approximate)
                       (Default: `0` - no limit)
+- `prescaleFactor`: Scale down (`< 1.0`) the subtitles canvas to improve
+                    performance at the expense of quality, or scale it up (`> 1.0`).
+                    (Default: `1.0` - no scaling; must be a number > 0)
+- `prescaleHeightLimit`: The height beyond which the subtitles canvas won't be prescaled.
+                         (Default: `1080`)
 
 ### Rendering Modes
 #### JS Blending

--- a/README.md
+++ b/README.md
@@ -137,6 +137,9 @@ When creating an instance of SubtitleOctopus, you can set the following options:
                     (Default: `1.0` - no scaling; must be a number > 0)
 - `prescaleHeightLimit`: The height beyond which the subtitles canvas won't be prescaled.
                          (Default: `1080`)
+- `maxRenderHeight`: The maximum rendering height of the subtitles canvas.
+                     Beyond this subtitles will be upscaled by the browser.
+                     (Default: `0` - no limit)
 
 ### Rendering Modes
 #### JS Blending

--- a/src/subtitles-octopus.js
+++ b/src/subtitles-octopus.js
@@ -19,6 +19,7 @@ var SubtitlesOctopus = function (options) {
     self.targetFps = options.targetFps || 24;
     self.prescaleFactor = options.prescaleFactor || 1.0;
     self.prescaleHeightLimit = options.prescaleHeightLimit || 1080;
+    self.maxRenderHeight = options.maxRenderHeight || 0; // 0 - no limit
     self.isOurCanvas = false; // (internal) we created canvas and manage it
     self.video = options.video; // HTML video element (optional if canvas specified)
     self.canvasParent = null; // (internal) HTML canvas parent element
@@ -419,6 +420,9 @@ var SubtitlesOctopus = function (options) {
                 newH *= scalefactor;
             else if (sgn * newH < sgn * self.prescaleHeightLimit)
                 newH = self.prescaleHeightLimit;
+
+            if (self.maxRenderHeight > 0 && newH > self.maxRenderHeight)
+                newH = self.maxRenderHeight;
 
             width *= newH / height;
             height = newH;


### PR DESCRIPTION
Cleaned and simplified (keeping the same results for positive saling values) version of https://github.com/libass/JavascriptSubtitlesOctopus/pull/119 backporting a jellyfin feature.
( @dmitrylyzo )

In particular I'd like to get some feedback on the name for the option added in the second commit: While I find `hardHeightLimit` to be an ok name, I was also considering `canvasHeightLimit`, `maxCanvasHeight` and `maxRenderingHeight` but I'm not sure if eg the `canvas`-names might cause confusion with the HTML-`<canvas>` element.

Another previously discussed topic was if I'd be better to bundle the `prescale` options into one object internally or also externally. I have no particular preference with regards to that.