### PR TITLE
fix resize

### DIFF
--- a/src/subtitles-octopus.js
+++ b/src/subtitles-octopus.js
@@ -453,14 +453,9 @@ var SubtitlesOctopus = function (options) {
 
 
         if (
-          self.canvas.width != width ||
-          self.canvas.height != height ||
-          self.canvas.style.top != top ||
-          self.canvas.style.left != left
+          self.canvas.style.top != top + 'px' ||
+          self.canvas.style.left != left + 'px'
         ) {
-            self.canvas.width = width;
-            self.canvas.height = height;
-
             if (videoSize != null) {
                 self.canvasParent.style.position = 'relative';
                 self.canvas.style.display = 'block';
@@ -471,6 +466,13 @@ var SubtitlesOctopus = function (options) {
                 self.canvas.style.left = left + 'px';
                 self.canvas.style.pointerEvents = 'none';
             }
+        }
+        if (
+          self.canvas.width != width ||
+          self.canvas.height != height
+        ) {
+            self.canvas.width = width;
+            self.canvas.height = height;
 
             self.worker.postMessage({
                 target: 'canvas',


### PR DESCRIPTION
changes:
- fix "top/left changed" check.
  - was comparing `style.top`/`style.left` (string with `px`suffix) with number.
- split "top/left changed" and "width/height changed" code.
  - `left`/`top` and `width`/`height` are not related.

fixes:
- canvas became empty because of unnecessary resize.
  - open [videojs.html](https://libass.github.io/JavascriptSubtitlesOctopus/videojs.html).
  - pause when subtitles are visible.
  - resize window by 1 pixel, video/canvas size is not changed.
  - subtitles disappear.