### PR TITLE
Buffer refactor and buffer bug fixes

### DIFF
--- a/src/SubtitleOctopus.cpp
+++ b/src/SubtitleOctopus.cpp
@@ -48,6 +48,7 @@ public:
      * object until the next call to get_rawbuf or clear.
      */
     void *get_rawbuf(size_t new_size, bool keep_content) {
+        if (!new_size) new_size = 1;
         if (size >= new_size) {
             if (size >= 1.3 * new_size) {
                 // big reduction request

--- a/src/SubtitleOctopus.cpp
+++ b/src/SubtitleOctopus.cpp
@@ -20,16 +20,16 @@
 
 int log_level = 3;
 
-class ReusableBuffer {
+class ReusableBuffer2D {
 private:
     void *buffer;
     size_t size;
     int lessen_counter;
 
 public:
-    ReusableBuffer(): buffer(NULL), size(0), lessen_counter(0) {}
+    ReusableBuffer2D(): buffer(NULL), size(0), lessen_counter(0) {}
 
-    ~ReusableBuffer() {
+    ~ReusableBuffer2D() {
         free(buffer);
     }
 
@@ -42,12 +42,16 @@ public:
 
     /*
      * Request a raw pointer to a buffer being able to hold at least
-     * the requested amount of data.
+     * x times y values of size member_size.
      * On failure NULL is returned.
      * The pointer is valid during the lifetime of the ReusableBuffer
      * object until the next call to get_rawbuf or clear.
      */
-    void *get_rawbuf(size_t new_size) {
+    void *get_rawbuf(size_t x, size_t y, size_t member_size) {
+        if (x > SIZE_MAX / member_size / y)
+            return NULL;
+
+        size_t new_size = x * y * member_size;
         if (!new_size) new_size = 1;
         if (size >= new_size) {
             if (size >= 1.3 * new_size) {
@@ -277,7 +281,7 @@ public:
         }
 
         // make float buffer for blending
-        float* buf = (float*)m_blend.get_rawbuf(sizeof(float) * width * height * 4);
+        float* buf = (float*)m_blend.get_rawbuf(width, height, sizeof(float) * 4);
         if (buf == NULL) {
             fprintf(stderr, "jso: cannot allocate buffer for blending\n");
             return &m_blendResult;
@@ -357,7 +361,7 @@ public:
     }
 
 private:
-    ReusableBuffer m_blend;
+    ReusableBuffer2D m_blend;
     RenderBlendResult m_blendResult;
 };
 

--- a/src/SubtitleOctopus.cpp
+++ b/src/SubtitleOctopus.cpp
@@ -47,7 +47,7 @@ public:
      * The pointer is valid during the lifetime of the ReusableBuffer
      * object until the next call to get_rawbuf or clear.
      */
-    void *get_rawbuf(size_t new_size, bool keep_content) {
+    void *get_rawbuf(size_t new_size) {
         if (!new_size) new_size = 1;
         if (size >= new_size) {
             if (size >= 1.3 * new_size) {
@@ -62,17 +62,12 @@ public:
             }
         }
 
-        void *newbuf;
-        if (keep_content) {
-            newbuf = realloc(buffer, new_size);
-        } else {
-            newbuf = malloc(new_size);
-        }
-        if (!newbuf) return NULL;
-
-        if (!keep_content) free(buffer);
-        buffer = newbuf;
-        size = new_size;
+        free(buffer);
+        buffer = malloc(new_size);
+        if (buffer)
+            size = new_size;
+        else
+            size = 0;
         lessen_counter = 0;
         return buffer;
     }
@@ -282,7 +277,7 @@ public:
         }
 
         // make float buffer for blending
-        float* buf = (float*)m_blend.get_rawbuf(sizeof(float) * width * height * 4, 0);
+        float* buf = (float*)m_blend.get_rawbuf(sizeof(float) * width * height * 4);
         if (buf == NULL) {
             fprintf(stderr, "jso: cannot allocate buffer for blending\n");
             return &m_blendResult;

--- a/src/SubtitleOctopus.cpp
+++ b/src/SubtitleOctopus.cpp
@@ -6,6 +6,7 @@
 #include <stdlib.h>
 #include <stdarg.h>
 #include <string.h>
+#include <cstdint>
 #include "../lib/libass/libass/ass.h"
 
 #include "libass.cpp"
@@ -22,11 +23,11 @@ int log_level = 3;
 class ReusableBuffer {
 private:
     void *buffer;
-    int size;
+    size_t size;
     int lessen_counter;
 
 public:
-    ReusableBuffer(): buffer(NULL), size(-1), lessen_counter(0) {}
+    ReusableBuffer(): buffer(NULL), size(0), lessen_counter(0) {}
 
     ~ReusableBuffer() {
         free(buffer);
@@ -35,7 +36,7 @@ public:
     void clear() {
         free(buffer);
         buffer = NULL;
-        size = -1;
+        size = 0;
         lessen_counter = 0;
     }
 
@@ -46,7 +47,7 @@ public:
      * The pointer is valid during the lifetime of the ReusableBuffer
      * object until the next call to get_rawbuf or clear.
      */
-    void *get_rawbuf(int new_size, bool keep_content) {
+    void *get_rawbuf(size_t new_size, bool keep_content) {
         if (size >= new_size) {
             if (size >= 1.3 * new_size) {
                 // big reduction request


### PR DESCRIPTION
The refactor into a class is part of the jellyfin backports and here followed up by various bug fixes. The class members have been refactored for clarity and unused functions dropped.
As I mentioned in [#120](https://github.com/libass/JavascriptSubtitlesOctopus/pull/120#issuecomment-1030927083), checking the size on each frame rather than only on resizes is somewhat superfluous now *(but already what happened before this change)* but apparently the "smart-blend" changes will require resizes on each frame. Let’s wait until those patches come in to see if this can be improved upon.