### PR TITLE
Jellyfin’s dropAllAnimations

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,12 @@ When creating an instance of SubtitleOctopus, you can set the following options:
 - `maxRenderHeight`: The maximum rendering height of the subtitles canvas.
                      Beyond this subtitles will be upscaled by the browser.
                      (Default: `0` - no limit)
+- `dropAllAnimations`: If set to true, attempt to discard all animated tags.
+                       Enabling this may severly mangle complex subtitles and
+                       should only be considered as an last ditch effort of uncertain success
+                       for hardware otherwise incapable of displaing anything.
+                       Will not reliably work with manually edited or allocated events.
+                       (Default: `false` - do nothing)
 
 ### Rendering Modes
 #### JS Blending

--- a/src/SubtitleOctopus.cpp
+++ b/src/SubtitleOctopus.cpp
@@ -107,6 +107,9 @@ public:
 } RenderBlendResult;
 
 class SubtitleOctopus {
+private:
+    ReusableBuffer2D m_blend;
+    RenderBlendResult m_blendResult;
 public:
     ASS_Library* ass_library;
     ASS_Renderer* ass_renderer;
@@ -362,10 +365,6 @@ public:
         m_blendResult.image = (unsigned char*)result;
         return &m_blendResult;
     }
-
-private:
-    ReusableBuffer2D m_blend;
-    RenderBlendResult m_blendResult;
 };
 
 int main(int argc, char *argv[]) { return 0; }

--- a/src/SubtitleOctopus.idl
+++ b/src/SubtitleOctopus.idl
@@ -171,6 +171,7 @@ interface SubtitleOctopus {
     attribute ASS_Renderer ass_renderer;
     attribute ASS_Library ass_library;
     void setLogLevel(long level);
+    void setDropAnimations(long value);
     void initLibrary(long frame_w, long frame_h);
     void createTrack(DOMString subfile);
     void createTrackMem(DOMString buf, unsigned long bufsize);

--- a/src/post-worker.js
+++ b/src/post-worker.js
@@ -8,6 +8,7 @@ self.nextIsRaf = false;
 self.lastCurrentTimeReceivedAt = Date.now();
 self.targetFps = 24;
 self.libassMemoryLimit = 0; // in MiB
+self.dropAllAnimations = false;
 
 self.width = 0;
 self.height = 0;
@@ -565,6 +566,7 @@ function onMessageFromMainEmscriptenThread(message) {
             self.targetFps = message.data.targetFps || self.targetFps;
             self.libassMemoryLimit = message.data.libassMemoryLimit || self.libassMemoryLimit;
             self.libassGlyphLimit = message.data.libassGlyphLimit || 0;
+            self.dropAllAnimations = !!message.data.dropAllAnimations || self.dropAllAnimations;
             removeRunDependency('worker-init');
             postMessage({
                 target: "ready",

--- a/src/pre-worker.js
+++ b/src/pre-worker.js
@@ -108,6 +108,7 @@ Module['onRuntimeInitialized'] = function () {
     self.blendH = Module._malloc(4);
 
     self.octObj.initLibrary(screen.width, screen.height);
+    self.octObj.setDropAnimations(self.dropAllAnimations);
     self.octObj.createTrack("/sub.ass");
     self.ass_track = self.octObj.track;
     self.ass_library = self.octObj.ass_library;

--- a/src/subtitles-octopus.js
+++ b/src/subtitles-octopus.js
@@ -20,6 +20,7 @@ var SubtitlesOctopus = function (options) {
     self.prescaleFactor = options.prescaleFactor || 1.0;
     self.prescaleHeightLimit = options.prescaleHeightLimit || 1080;
     self.maxRenderHeight = options.maxRenderHeight || 0; // 0 - no limit
+    self.dropAllAnimations = options.dropAllAnimations || false; // attempt to remove all animations as a last ditch effort for displaying on weak hardware; may severly mangle subtitles if enabled
     self.isOurCanvas = false; // (internal) we created canvas and manage it
     self.video = options.video; // HTML video element (optional if canvas specified)
     self.canvasParent = null; // (internal) HTML canvas parent element
@@ -113,7 +114,8 @@ var SubtitlesOctopus = function (options) {
             debug: self.debug,
             targetFps: self.targetFps,
             libassMemoryLimit: self.libassMemoryLimit,
-            libassGlyphLimit: self.libassGlyphLimit
+            libassGlyphLimit: self.libassGlyphLimit,
+            dropAllAnimations: self.dropAllAnimations
         });
     };
 


### PR DESCRIPTION
Adds the corrected core animation detection and deletion code for `dropAllAnimations` and `renderAhead` and backports `dropAnimations` from jellyfin.

@dmitrylyzo Could you take a look at this to check if I missed to backport any relevant fixes for `dropAllAnimations`? In particular there’s https://github.com/libass/JavascriptSubtitlesOctopus/pull/111/commits/08f72cd094f7ee477a3dc8645101fb40d8f413a9 which refers to “lite mode” in its title, but iiuc the actual changes are all in the `renderAhead` portion.