### PR TITLE
Build cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ subtitleoctopus: dist
 
 include functions.mk
 
-# Fribidi
+# FriBidi
 build/lib/fribidi/configure: lib/fribidi $(wildcard $(BASE_DIR)build/patches/fribidi/*.patch)
 	$(call PREPARE_SRC_PATCHED,fribidi)
 	cd build/lib/fribidi && $(RECONF_AUTO)
@@ -32,6 +32,7 @@ $(DIST_DIR)/lib/libfribidi.a: build/lib/fribidi/configure
 	$(JSO_MAKE) -C lib/ install && \
 	$(JSO_MAKE) install-pkgconfigDATA
 
+# Expat
 build/lib/expat/configured: lib/expat
 	$(call PREPARE_SRC_VPATH,expat)
 	touch build/lib/expat/configured
@@ -49,6 +50,7 @@ $(DIST_DIR)/lib/libexpat.a: build/lib/expat/configured
 	$(JSO_MAKE) && \
 	$(JSO_MAKE) install
 
+# Brotli
 build/lib/brotli/js/decode.js: build/lib/brotli/configured
 build/lib/brotli/js/polyfill.js: build/lib/brotli/configured
 build/lib/brotli/configured: lib/brotli $(wildcard $(BASE_DIR)build/patches/brotli/*.patch)
@@ -66,11 +68,11 @@ $(DIST_DIR)/lib/libbrotlicommon.a: build/lib/brotli/configured
 	for lib in *-static.a ; do mv "$$lib" "$${lib%-static.a}.a" ; done
 
 
+# Freetype without Harfbuzz
 build/lib/freetype/configure: lib/freetype $(wildcard $(BASE_DIR)build/patches/freetype/*.patch)
 	$(call PREPARE_SRC_PATCHED,freetype)
 	cd build/lib/freetype && $(RECONF_AUTO)
 
-# Freetype without Harfbuzz
 build/lib/freetype/build_hb/dist_hb/lib/libfreetype.a: $(DIST_DIR)/lib/libbrotlidec.a build/lib/freetype/configure
 	cd build/lib/freetype && \
 		mkdir -p build_hb && \
@@ -125,8 +127,8 @@ $(DIST_DIR)/lib/libfontconfig.a: $(DIST_DIR)/lib/libharfbuzz.a $(DIST_DIR)/lib/l
 	$(JSO_MAKE) -C fontconfig/ install && \
 	$(JSO_MAKE) install-pkgconfigDATA
 
-# libass --
 
+# libass
 build/lib/libass/configured: lib/libass
 	cd lib/libass && $(RECONF_AUTO)
 	$(call PREPARE_SRC_VPATH,libass)

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,6 @@ $(DIST_DIR)/lib/libfribidi.a: build/lib/fribidi/configure
 	emconfigure ./configure \
 		CFLAGS=" \
 		$(GLOBAL_CFLAGS) \
-		-DFRIBIDI_ENTRY=extern \
 		" \
 		--prefix="$(DIST_DIR)" \
 		--host=x86-none-linux \

--- a/Makefile
+++ b/Makefile
@@ -17,11 +17,8 @@ include functions.mk
 
 # Fribidi
 build/lib/fribidi/configure: lib/fribidi $(wildcard $(BASE_DIR)build/patches/fribidi/*.patch)
-	rm -rf build/lib/fribidi
-	mkdir -p build/lib
-	cp -r lib/fribidi build/lib/fribidi
-	$(foreach file, $(wildcard $(BASE_DIR)build/patches/fribidi/*.patch), patch -d "$(BASE_DIR)build/lib/fribidi" -Np1 -i $(file) && ) true
-	cd build/lib/fribidi && NOCONFIGURE=1 ./autogen.sh
+	$(call PREPARE_SRC_PATCHED,fribidi)
+	cd build/lib/fribidi && $(RECONF_AUTO)
 
 $(DIST_DIR)/lib/libfribidi.a: build/lib/fribidi/configure
 	cd build/lib/fribidi && \
@@ -41,7 +38,7 @@ $(DIST_DIR)/lib/libfribidi.a: build/lib/fribidi/configure
 	emmake make install-pkgconfigDATA
 
 build/lib/expat/configured: lib/expat
-	mkdir -p build/lib/expat
+	$(call PREPARE_SRC_VPATH,expat)
 	touch build/lib/expat/configured
 
 $(DIST_DIR)/lib/libexpat.a: build/lib/expat/configured
@@ -65,9 +62,7 @@ $(DIST_DIR)/lib/libexpat.a: build/lib/expat/configured
 build/lib/brotli/js/decode.js: build/lib/brotli/configured
 build/lib/brotli/js/polyfill.js: build/lib/brotli/configured
 build/lib/brotli/configured: lib/brotli $(wildcard $(BASE_DIR)build/patches/brotli/*.patch)
-	rm -rf build/lib/brotli
-	cp -r lib/brotli build/lib/brotli
-	$(foreach file, $(wildcard $(BASE_DIR)build/patches/brotli/*.patch), patch -d "$(BASE_DIR)build/lib/brotli" -Np1 -i $(file) && ) true
+	$(call PREPARE_SRC_PATCHED,brotli)
 	touch build/lib/brotli/configured
 
 $(DIST_DIR)/lib/libbrotlidec.a: $(DIST_DIR)/lib/libbrotlicommon.a
@@ -87,13 +82,13 @@ $(DIST_DIR)/lib/libbrotlicommon.a: build/lib/brotli/configured
 	for lib in *-static.a ; do mv "$$lib" "$${lib%-static.a}.a" ; done
 
 
+build/lib/freetype/configure: lib/freetype $(wildcard $(BASE_DIR)build/patches/freetype/*.patch)
+	$(call PREPARE_SRC_PATCHED,freetype)
+	cd build/lib/freetype && $(RECONF_AUTO)
+
 # Freetype without Harfbuzz
-build/lib/freetype/build_hb/dist_hb/lib/libfreetype.a: $(DIST_DIR)/lib/libbrotlidec.a $(wildcard $(BASE_DIR)build/patches/freetype/*.patch)
-	rm -rf build/lib/freetype
-	cp -r lib/freetype build/lib/freetype
-	$(foreach file, $(wildcard $(BASE_DIR)build/patches/freetype/*.patch), patch -d "$(BASE_DIR)build/lib/freetype" -Np1 -i $(file) && ) true
+build/lib/freetype/build_hb/dist_hb/lib/libfreetype.a: $(DIST_DIR)/lib/libbrotlidec.a build/lib/freetype/configure
 	cd build/lib/freetype && \
-		NOCONFIGURE=1 ./autogen.sh && \
 		mkdir -p build_hb && \
 		cd build_hb && \
 		EM_PKG_CONFIG_PATH=$(DIST_DIR)/lib/pkgconfig \
@@ -118,10 +113,8 @@ build/lib/freetype/build_hb/dist_hb/lib/libfreetype.a: $(DIST_DIR)/lib/libbrotli
 
 # Harfbuzz
 build/lib/harfbuzz/configure: lib/harfbuzz $(wildcard $(BASE_DIR)build/patches/harfbuzz/*.patch)
-	rm -rf build/lib/harfbuzz
-	cp -r lib/harfbuzz build/lib/harfbuzz
-	$(foreach file, $(wildcard $(BASE_DIR)build/patches/harfbuzz/*.patch), patch -d "$(BASE_DIR)build/lib/harfbuzz" -Np1 -i $(file) && ) true
-	cd build/lib/harfbuzz && NOCONFIGURE=1 ./autogen.sh
+	$(call PREPARE_SRC_PATCHED,harfbuzz)
+	cd build/lib/harfbuzz && $(RECONF_AUTO)
 
 $(DIST_DIR)/lib/libharfbuzz.a: build/lib/freetype/build_hb/dist_hb/lib/libfreetype.a build/lib/harfbuzz/configure
 	cd build/lib/harfbuzz && \
@@ -176,10 +169,8 @@ $(DIST_DIR)/lib/libfreetype.a: $(DIST_DIR)/lib/libharfbuzz.a $(DIST_DIR)/lib/lib
 
 # Fontconfig
 build/lib/fontconfig/configure: lib/fontconfig $(wildcard $(BASE_DIR)build/patches/fontconfig/*.patch)
-	rm -rf build/lib/fontconfig
-	cp -r lib/fontconfig build/lib/fontconfig
-	$(foreach file, $(wildcard $(BASE_DIR)build/patches/fontconfig/*.patch), patch -d "$(BASE_DIR)build/lib/fontconfig" -Np1 -i $(file) && ) true
-	cd build/lib/fontconfig && NOCONFIGURE=1 ./autogen.sh
+	$(call PREPARE_SRC_PATCHED,fontconfig)
+	cd build/lib/fontconfig && $(RECONF_AUTO)
 
 $(DIST_DIR)/lib/libfontconfig.a: $(DIST_DIR)/lib/libharfbuzz.a $(DIST_DIR)/lib/libexpat.a $(DIST_DIR)/lib/libfribidi.a $(DIST_DIR)/lib/libfreetype.a build/lib/fontconfig/configure
 	cd build/lib/fontconfig && \
@@ -203,9 +194,8 @@ $(DIST_DIR)/lib/libfontconfig.a: $(DIST_DIR)/lib/libharfbuzz.a $(DIST_DIR)/lib/l
 # libass --
 
 build/lib/libass/configured: lib/libass
-	rm -rf build/lib/libass
-	cd lib/libass && NOCONFIGURE=1 ./autogen.sh
-	mkdir -p build/lib/libass
+	cd lib/libass && $(RECONF_AUTO)
+	$(call PREPARE_SRC_VPATH,libass)
 	touch build/lib/libass/configured
 
 $(DIST_DIR)/lib/libass.a: $(DIST_DIR)/lib/libfontconfig.a $(DIST_DIR)/lib/libharfbuzz.a $(DIST_DIR)/lib/libexpat.a $(DIST_DIR)/lib/libfribidi.a $(DIST_DIR)/lib/libfreetype.a $(DIST_DIR)/lib/libbrotlidec.a build/lib/libass/configured

--- a/Makefile
+++ b/Makefile
@@ -194,7 +194,6 @@ $(DIST_DIR)/lib/libfontconfig.a: $(DIST_DIR)/lib/libharfbuzz.a $(DIST_DIR)/lib/l
 	EM_PKG_CONFIG_PATH=$(DIST_DIR)/lib/pkgconfig \
 	emconfigure ./configure \
 		CFLAGS=" \
-		-DEMSCRIPTEN \
 		$(GLOBAL_CFLAGS) \
 		" \
 		--prefix="$(DIST_DIR)" \

--- a/Makefile
+++ b/Makefile
@@ -105,9 +105,6 @@ build/lib/freetype/build_hb/dist_hb/lib/libfreetype.a: $(DIST_DIR)/lib/libbrotli
 			--disable-shared \
 			\
 			--with-brotli=yes \
-			--without-zlib \
-			--without-bzip2 \
-			--without-png \
 			--without-harfbuzz \
 		&& \
 		emmake make -j8 && \
@@ -137,11 +134,7 @@ $(DIST_DIR)/lib/libharfbuzz.a: build/lib/freetype/build_hb/dist_hb/lib/libfreety
 		--disable-shared \
 		--disable-dependency-tracking \
 		\
-		--without-cairo \
-		--without-fontconfig \
-		--without-icu \
 		--with-freetype \
-		--without-glib \
 	&& \
 	cd src && \
 	emmake make -j8 install-libLTLIBRARIES install-pkgincludeHEADERS install-pkgconfigDATA
@@ -161,9 +154,6 @@ $(DIST_DIR)/lib/libfreetype.a: $(DIST_DIR)/lib/libharfbuzz.a $(DIST_DIR)/lib/lib
 		--disable-shared \
 		\
 		--with-brotli=yes \
-		--without-zlib \
-		--without-bzip2 \
-		--without-png \
 		--with-harfbuzz \
 	&& \
 	emmake make -j8 && \

--- a/Makefile
+++ b/Makefile
@@ -169,10 +169,6 @@ EMCC_COMMON_ARGS = \
 	-s NO_FILESYSTEM=0 \
 	--no-heap-copy \
 	-o $@
-	#--js-opts 0 -g4 \
-	#--closure 1 \
-	#--memory-init-file 0 \
-	#-s OUTLINING_LIMIT=20000 \
 
 dist: src/subtitles-octopus-worker.bc dist/js/subtitles-octopus-worker.js dist/js/subtitles-octopus-worker-legacy.js dist/js/subtitles-octopus.js dist/js/COPYRIGHT
 

--- a/Makefile
+++ b/Makefile
@@ -27,15 +27,7 @@ build/lib/fribidi/configure: lib/fribidi $(wildcard $(BASE_DIR)build/patches/fri
 
 $(DIST_DIR)/lib/libfribidi.a: build/lib/fribidi/configure
 	cd build/lib/fribidi && \
-	emconfigure ./configure \
-		--prefix="$(DIST_DIR)" \
-		--host=x86-none-linux \
-		--build=x86_64 \
-		--enable-static \
-		--disable-shared \
-		--disable-dependency-tracking \
-		--disable-debug \
-	&& \
+	$(call CONFIGURE_AUTO) && \
 	emmake make -C lib/ install && \
 	emmake make install-pkgconfigDATA
 
@@ -45,15 +37,13 @@ build/lib/expat/configured: lib/expat
 
 $(DIST_DIR)/lib/libexpat.a: build/lib/expat/configured
 	cd build/lib/expat && \
-	emcmake cmake \
-		-DCMAKE_INSTALL_PREFIX=$(DIST_DIR) \
+	$(call CONFIGURE_CMAKE,$(BASE_DIR)lib/expat/expat) \
 		-DEXPAT_BUILD_DOCS=off \
 		-DEXPAT_SHARED_LIBS=off \
 		-DEXPAT_BUILD_EXAMPLES=off \
 		-DEXPAT_BUILD_FUZZERS=off \
 		-DEXPAT_BUILD_TESTS=off \
 		-DEXPAT_BUILD_TOOLS=off \
-		$(BASE_DIR)lib/expat/expat \
 	&& \
 	emmake make -j8 && \
 	emmake make install
@@ -67,10 +57,7 @@ build/lib/brotli/configured: lib/brotli $(wildcard $(BASE_DIR)build/patches/brot
 $(DIST_DIR)/lib/libbrotlidec.a: $(DIST_DIR)/lib/libbrotlicommon.a
 $(DIST_DIR)/lib/libbrotlicommon.a: build/lib/brotli/configured
 	cd build/lib/brotli && \
-    emcmake cmake \
-        -DCMAKE_INSTALL_PREFIX=$(DIST_DIR) \
-        . \
-    && \
+    $(call CONFIGURE_CMAKE) && \
     emmake make -j8 && \
 	emmake make install
 	# Normalise static lib names
@@ -87,13 +74,8 @@ build/lib/freetype/build_hb/dist_hb/lib/libfreetype.a: $(DIST_DIR)/lib/libbrotli
 	cd build/lib/freetype && \
 		mkdir -p build_hb && \
 		cd build_hb && \
-		emconfigure ../configure \
+		$(call CONFIGURE_AUTO,..) \
 			--prefix="$$(pwd)/dist_hb" \
-			--host=x86-none-linux \
-			--build=x86_64 \
-			--enable-static \
-			--disable-shared \
-			\
 			--with-brotli=yes \
 			--without-harfbuzz \
 		&& \
@@ -110,14 +92,7 @@ $(DIST_DIR)/lib/libharfbuzz.a: build/lib/freetype/build_hb/dist_hb/lib/libfreety
 	EM_PKG_CONFIG_PATH=$(PKG_CONFIG_PATH):$(BASE_DIR)build/lib/freetype/build_hb/dist_hb/lib/pkgconfig \
 	CFLAGS="-DHB_NO_MT $(CFLAGS)" \
 	CXXFLAGS="-DHB_NO_MT $(CFLAGS)" \
-	emconfigure ./configure \
-		--prefix="$(DIST_DIR)" \
-		--host=x86-none-linux \
-		--build=x86_64 \
-		--enable-static \
-		--disable-shared \
-		--disable-dependency-tracking \
-		\
+	$(call CONFIGURE_AUTO) \
 		--with-freetype \
 	&& \
 	cd src && \
@@ -127,13 +102,7 @@ $(DIST_DIR)/lib/libharfbuzz.a: build/lib/freetype/build_hb/dist_hb/lib/libfreety
 $(DIST_DIR)/lib/libfreetype.a: $(DIST_DIR)/lib/libharfbuzz.a $(DIST_DIR)/lib/libbrotlidec.a
 	cd build/lib/freetype && \
 	EM_PKG_CONFIG_PATH=$(PKG_CONFIG_PATH):$(BASE_DIR)build/lib/freetype/build_hb/dist_hb/lib/pkgconfig \
-	emconfigure ./configure \
-		--prefix="$(DIST_DIR)" \
-		--host=x86-none-linux \
-		--build=x86_64 \
-		--enable-static \
-		--disable-shared \
-		\
+	$(call CONFIGURE_AUTO) \
 		--with-brotli=yes \
 		--with-harfbuzz \
 	&& \
@@ -147,12 +116,7 @@ build/lib/fontconfig/configure: lib/fontconfig $(wildcard $(BASE_DIR)build/patch
 
 $(DIST_DIR)/lib/libfontconfig.a: $(DIST_DIR)/lib/libharfbuzz.a $(DIST_DIR)/lib/libexpat.a $(DIST_DIR)/lib/libfribidi.a $(DIST_DIR)/lib/libfreetype.a build/lib/fontconfig/configure
 	cd build/lib/fontconfig && \
-	emconfigure ./configure \
-		--prefix="$(DIST_DIR)" \
-		--host=x86-none-linux \
-		--build=x86_64 \
-		--disable-shared \
-		--enable-static \
+	$(call CONFIGURE_AUTO) \
 		--disable-docs \
 		--with-default-fonts=/fonts \
 	&& \
@@ -169,15 +133,8 @@ build/lib/libass/configured: lib/libass
 
 $(DIST_DIR)/lib/libass.a: $(DIST_DIR)/lib/libfontconfig.a $(DIST_DIR)/lib/libharfbuzz.a $(DIST_DIR)/lib/libexpat.a $(DIST_DIR)/lib/libfribidi.a $(DIST_DIR)/lib/libfreetype.a $(DIST_DIR)/lib/libbrotlidec.a build/lib/libass/configured
 	cd build/lib/libass && \
-	emconfigure ../../../lib/libass/configure \
-		--prefix="$(DIST_DIR)" \
-		--host=x86-none-linux \
-		--build=x86_64 \
-		--disable-shared \
-		--enable-static \
+	$(call CONFIGURE_AUTO,../../../lib/libass) \
 		--disable-asm \
-		\
-		--enable-harfbuzz \
 		--enable-fontconfig \
 	&& \
 	emmake make -j8 && \

--- a/Makefile
+++ b/Makefile
@@ -4,12 +4,9 @@
 BASE_DIR:=$(dir $(realpath $(firstword $(MAKEFILE_LIST))))
 DIST_DIR:=$(BASE_DIR)dist/libraries
 
-GLOBAL_CFLAGS:=-O3 -s USE_PTHREADS=0
-GLOBAL_LDFLAGS:=-s ENVIRONMENT=web,webview,worker -s NO_EXIT_RUNTIME=1
-export LDFLAGS = $(GLOBAL_LDFLAGS)
-export CFLAGS = $(GLOBAL_CFLAGS)
-export CXXFLAGS = $(GLOBAL_CFLAGS)
-
+export LDFLAGS = -s ENVIRONMENT=web,webview,worker -s NO_EXIT_RUNTIME=1
+export CFLAGS = -O3 -s USE_PTHREADS=0
+export CXXFLAGS = $(CFLAGS)
 export PKG_CONFIG_PATH = $(DIST_DIR)/lib/pkgconfig
 export EM_PKG_CONFIG_PATH = $(PKG_CONFIG_PATH)
 
@@ -161,7 +158,7 @@ all-src:
 
 # Dist Files
 EMCC_COMMON_ARGS = \
-	$(GLOBAL_LDFLAGS) \
+	$(LDFLAGS) \
 	-s EXPORTED_FUNCTIONS="['_main', '_malloc']" \
 	-s EXPORTED_RUNTIME_METHODS="['ccall', 'cwrap', 'getValue', 'FS_createPreloadedFile', 'FS_createPath']" \
 	--use-preload-plugins \

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,6 @@ $(DIST_DIR)/lib/libexpat.a: build/lib/expat/configured
 		-DEXPAT_BUILD_TESTS=off \
 		-DEXPAT_BUILD_TOOLS=off \
 	&& \
-	$(JSO_MAKE) && \
 	$(JSO_MAKE) install
 
 # Brotli
@@ -58,7 +57,6 @@ $(DIST_DIR)/lib/libbrotlidec.a: $(DIST_DIR)/lib/libbrotlicommon.a
 $(DIST_DIR)/lib/libbrotlicommon.a: build/lib/brotli/configured
 	cd build/lib/brotli && \
     $(call CONFIGURE_CMAKE) && \
-    $(JSO_MAKE) && \
 	$(JSO_MAKE) install
 	# Normalise static lib names
 	cd $(DIST_DIR)/lib/ && \
@@ -79,7 +77,6 @@ build/lib/freetype/build_hb/dist_hb/lib/libfreetype.a: $(DIST_DIR)/lib/libbrotli
 			--with-brotli=yes \
 			--without-harfbuzz \
 		&& \
-		$(JSO_MAKE) && \
 		$(JSO_MAKE) install
 
 # Harfbuzz
@@ -106,7 +103,6 @@ $(DIST_DIR)/lib/libfreetype.a: $(DIST_DIR)/lib/libharfbuzz.a $(DIST_DIR)/lib/lib
 		--with-brotli=yes \
 		--with-harfbuzz \
 	&& \
-	$(JSO_MAKE) && \
 	$(JSO_MAKE) install
 
 # Fontconfig
@@ -137,7 +133,6 @@ $(DIST_DIR)/lib/libass.a: $(DIST_DIR)/lib/libfontconfig.a $(DIST_DIR)/lib/libhar
 		--disable-asm \
 		--enable-fontconfig \
 	&& \
-	$(JSO_MAKE) && \
 	$(JSO_MAKE) install
 
 # SubtitleOctopus.js

--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,9 @@ GLOBAL_LDFLAGS:=-s ENVIRONMENT=web,webview,worker -s NO_EXIT_RUNTIME=1
 export LDFLAGS = $(GLOBAL_LDFLAGS)
 
 all: subtitleoctopus
-
 subtitleoctopus: dist
+
+.PHONY: all subtitleoctopus dist
 
 include functions.mk
 
@@ -367,3 +368,5 @@ $(foreach subm, $(SUBMODULES), $(eval $(call TR_GIT_SM_RESET,$(subm))))
 
 server: # Node http server npm i -g http-server
 	http-server
+
+.PHONY: clean clean-dist clean-libs clean-octopus git-checkout git-smreset server

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,8 @@ all: subtitleoctopus
 
 subtitleoctopus: dist
 
+include functions.mk
+
 # Fribidi
 build/lib/fribidi/configure: lib/fribidi $(wildcard $(BASE_DIR)build/patches/fribidi/*.patch)
 	rm -rf build/lib/fribidi
@@ -361,46 +363,8 @@ git-checkout:
 server: # Node http server npm i -g http-server
 	http-server
 
-git-update: git-freetype git-fribidi git-fontconfig git-expat git-harfbuzz git-libass git-brotli
 
-git-brotli:
-	cd lib/brotli && \
-	git reset --hard && \
-	git clean -dfx && \
-	git pull origin master
+SUBMODULES := brotli expat fontconfig freetype fribidi harfbuzz libass
+git-update: $(addprefix git-, $(SUBMODULES))
 
-git-freetype:
-	cd lib/freetype && \
-	git reset --hard && \
-	git clean -dfx && \
-	git pull origin master
-
-git-fribidi:
-	cd lib/fribidi && \
-	git reset --hard && \
-	git clean -dfx && \
-	git pull origin master
-
-git-fontconfig:
-	cd lib/fontconfig && \
-	git reset --hard && \
-	git clean -dfx && \
-	git pull origin master
-
-git-expat:
-	cd lib/expat && \
-	git reset --hard && \
-	git clean -dfx && \
-	git pull origin master
-
-git-harfbuzz:
-	cd lib/harfbuzz && \
-	git reset --hard && \
-	git clean -dfx && \
-	git pull origin master
-
-git-libass:
-	cd lib/libass && \
-	git reset --hard && \
-	git clean -dfx && \
-	git pull origin master
+$(foreach subm, $(SUBMODULES), $(eval $(call TR_GIT_SM_UPDATE,$(subm))))

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 BASE_DIR:=$(dir $(realpath $(firstword $(MAKEFILE_LIST))))
 DIST_DIR:=$(BASE_DIR)dist/libraries
 
-GLOBAL_CFLAGS:=-O3
+GLOBAL_CFLAGS:=-O3 -s USE_PTHREADS=0
 GLOBAL_LDFLAGS:=-s ENVIRONMENT=web,webview,worker -s NO_EXIT_RUNTIME=1
 export LDFLAGS = $(GLOBAL_LDFLAGS)
 
@@ -27,7 +27,6 @@ $(DIST_DIR)/lib/libfribidi.a: build/lib/fribidi/configure
 	cd build/lib/fribidi && \
 	emconfigure ./configure \
 		CFLAGS=" \
-		-s USE_PTHREADS=0 \
 		$(GLOBAL_CFLAGS) \
 		-DFRIBIDI_ENTRY=extern \
 		" \
@@ -50,7 +49,6 @@ $(DIST_DIR)/lib/libexpat.a: build/lib/expat/configured
 	cd build/lib/expat && \
 	emcmake cmake \
 		-DCMAKE_C_FLAGS=" \
-		-s USE_PTHREADS=0 \
 		$(GLOBAL_CFLAGS) \
 		" \
 		-DCMAKE_INSTALL_PREFIX=$(DIST_DIR) \
@@ -109,7 +107,6 @@ build/lib/freetype/build_hb/dist_hb/lib/libfreetype.a: $(DIST_DIR)/lib/libbrotli
 		EM_PKG_CONFIG_PATH=$(DIST_DIR)/lib/pkgconfig \
 		emconfigure ../configure \
 			CFLAGS=" \
-			-s USE_PTHREADS=0 \
 			$(GLOBAL_CFLAGS) \
 			" \
 			--prefix="$$(pwd)/dist_hb" \
@@ -139,12 +136,10 @@ $(DIST_DIR)/lib/libharfbuzz.a: build/lib/freetype/build_hb/dist_hb/lib/libfreety
 	EM_PKG_CONFIG_PATH=$(DIST_DIR)/lib/pkgconfig:$(BASE_DIR)build/lib/freetype/build_hb/dist_hb/lib/pkgconfig \
 	emconfigure ./configure \
 		CFLAGS=" \
-		-s USE_PTHREADS=0 \
 		$(GLOBAL_CFLAGS) \
 		-DHB_NO_MT \
 		" \
 		CXXFLAGS=" \
-		-s USE_PTHREADS=0 \
 		$(GLOBAL_CFLAGS) \
 		-DHB_NO_MT \
 		" \
@@ -170,7 +165,6 @@ $(DIST_DIR)/lib/libfreetype.a: $(DIST_DIR)/lib/libharfbuzz.a $(DIST_DIR)/lib/lib
 	EM_PKG_CONFIG_PATH=$(DIST_DIR)/lib/pkgconfig:$(BASE_DIR)build/lib/freetype/build_hb/dist_hb/lib/pkgconfig \
 	emconfigure ./configure \
 		CFLAGS=" \
-		-s USE_PTHREADS=0 \
 		$(GLOBAL_CFLAGS) \
 		" \
 		--prefix="$(DIST_DIR)" \
@@ -200,7 +194,6 @@ $(DIST_DIR)/lib/libfontconfig.a: $(DIST_DIR)/lib/libharfbuzz.a $(DIST_DIR)/lib/l
 	EM_PKG_CONFIG_PATH=$(DIST_DIR)/lib/pkgconfig \
 	emconfigure ./configure \
 		CFLAGS=" \
-		-s USE_PTHREADS=0 \
 		-DEMSCRIPTEN \
 		$(GLOBAL_CFLAGS) \
 		" \
@@ -229,7 +222,6 @@ $(DIST_DIR)/lib/libass.a: $(DIST_DIR)/lib/libfontconfig.a $(DIST_DIR)/lib/libhar
 	EM_PKG_CONFIG_PATH=$(DIST_DIR)/lib/pkgconfig \
 	emconfigure ../../../lib/libass/configure \
 		CFLAGS=" \
-		-s USE_PTHREADS=0 \
 		$(GLOBAL_CFLAGS) \
 		" \
 		--prefix="$(DIST_DIR)" \

--- a/Makefile
+++ b/Makefile
@@ -360,11 +360,10 @@ git-checkout:
 	git submodule sync --recursive && \
 	git submodule update --init --recursive
 
-server: # Node http server npm i -g http-server
-	http-server
-
-
 SUBMODULES := brotli expat fontconfig freetype fribidi harfbuzz libass
 git-smreset: $(addprefix git-, $(SUBMODULES))
 
 $(foreach subm, $(SUBMODULES), $(eval $(call TR_GIT_SM_RESET,$(subm))))
+
+server: # Node http server npm i -g http-server
+	http-server

--- a/Makefile
+++ b/Makefile
@@ -28,8 +28,9 @@ build/lib/fribidi/configure: lib/fribidi $(wildcard $(BASE_DIR)build/patches/fri
 $(DIST_DIR)/lib/libfribidi.a: build/lib/fribidi/configure
 	cd build/lib/fribidi && \
 	$(call CONFIGURE_AUTO) && \
-	emmake make -C lib/ install && \
-	emmake make install-pkgconfigDATA
+	$(JSO_MAKE) -C lib/ fribidi-unicode-version.h && \
+	$(JSO_MAKE) -C lib/ install && \
+	$(JSO_MAKE) install-pkgconfigDATA
 
 build/lib/expat/configured: lib/expat
 	$(call PREPARE_SRC_VPATH,expat)
@@ -45,8 +46,8 @@ $(DIST_DIR)/lib/libexpat.a: build/lib/expat/configured
 		-DEXPAT_BUILD_TESTS=off \
 		-DEXPAT_BUILD_TOOLS=off \
 	&& \
-	emmake make -j8 && \
-	emmake make install
+	$(JSO_MAKE) && \
+	$(JSO_MAKE) install
 
 build/lib/brotli/js/decode.js: build/lib/brotli/configured
 build/lib/brotli/js/polyfill.js: build/lib/brotli/configured
@@ -58,8 +59,8 @@ $(DIST_DIR)/lib/libbrotlidec.a: $(DIST_DIR)/lib/libbrotlicommon.a
 $(DIST_DIR)/lib/libbrotlicommon.a: build/lib/brotli/configured
 	cd build/lib/brotli && \
     $(call CONFIGURE_CMAKE) && \
-    emmake make -j8 && \
-	emmake make install
+    $(JSO_MAKE) && \
+	$(JSO_MAKE) install
 	# Normalise static lib names
 	cd $(DIST_DIR)/lib/ && \
 	for lib in *-static.a ; do mv "$$lib" "$${lib%-static.a}.a" ; done
@@ -79,8 +80,8 @@ build/lib/freetype/build_hb/dist_hb/lib/libfreetype.a: $(DIST_DIR)/lib/libbrotli
 			--with-brotli=yes \
 			--without-harfbuzz \
 		&& \
-		emmake make -j8 && \
-		emmake make install
+		$(JSO_MAKE) && \
+		$(JSO_MAKE) install
 
 # Harfbuzz
 build/lib/harfbuzz/configure: lib/harfbuzz $(wildcard $(BASE_DIR)build/patches/harfbuzz/*.patch)
@@ -96,7 +97,7 @@ $(DIST_DIR)/lib/libharfbuzz.a: build/lib/freetype/build_hb/dist_hb/lib/libfreety
 		--with-freetype \
 	&& \
 	cd src && \
-	emmake make -j8 install-libLTLIBRARIES install-pkgincludeHEADERS install-pkgconfigDATA
+	$(JSO_MAKE) install-libLTLIBRARIES install-pkgincludeHEADERS install-pkgconfigDATA
 
 # Freetype with Harfbuzz
 $(DIST_DIR)/lib/libfreetype.a: $(DIST_DIR)/lib/libharfbuzz.a $(DIST_DIR)/lib/libbrotlidec.a
@@ -106,8 +107,8 @@ $(DIST_DIR)/lib/libfreetype.a: $(DIST_DIR)/lib/libharfbuzz.a $(DIST_DIR)/lib/lib
 		--with-brotli=yes \
 		--with-harfbuzz \
 	&& \
-	emmake make -j8 && \
-	emmake make install
+	$(JSO_MAKE) && \
+	$(JSO_MAKE) install
 
 # Fontconfig
 build/lib/fontconfig/configure: lib/fontconfig $(wildcard $(BASE_DIR)build/patches/fontconfig/*.patch)
@@ -120,9 +121,9 @@ $(DIST_DIR)/lib/libfontconfig.a: $(DIST_DIR)/lib/libharfbuzz.a $(DIST_DIR)/lib/l
 		--disable-docs \
 		--with-default-fonts=/fonts \
 	&& \
-	emmake make -C src/ install && \
-	emmake make -C fontconfig/ install && \
-	emmake make install-pkgconfigDATA
+	$(JSO_MAKE) -C src/ install && \
+	$(JSO_MAKE) -C fontconfig/ install && \
+	$(JSO_MAKE) install-pkgconfigDATA
 
 # libass --
 
@@ -137,8 +138,8 @@ $(DIST_DIR)/lib/libass.a: $(DIST_DIR)/lib/libfontconfig.a $(DIST_DIR)/lib/libhar
 		--disable-asm \
 		--enable-fontconfig \
 	&& \
-	emmake make -j8 && \
-	emmake make install
+	$(JSO_MAKE) && \
+	$(JSO_MAKE) install
 
 # SubtitleOctopus.js
 OCTP_DEPS = \

--- a/Makefile
+++ b/Makefile
@@ -205,36 +205,9 @@ dist/js/subtitles-octopus.js: dist/license/all src/subtitles-octopus.js
 	mkdir -p dist/js
 	awk '1 {print "// "$$0}' dist/license/all | cat - src/subtitles-octopus.js > $@
 
-LIB_LICENSES := brotli expat freetype fribidi fontconfig harfbuzz libass
-LIB_LICENSES_FINDOPT_brotli   := -path ./research -prune -false -o ! -path ./js/decode.min.js
-LIB_LICENSES_FINDOPT_expat    := -path ./expat/fuzz -prune -false -o
-LIB_LICENSES_FINDOPT_freetype := -path ./src/tools -prune -false -o
-LIB_LICENSES_FINDOPT_fribidi  := -path ./bin -prune -false -o
-LIB_LICENSES_FINDOPT_harfbuzz := -path ./test -prune -false -o
-
-$(addprefix dist/license/, $(LIB_LICENSES)): dist/license/%: .git/modules/lib/%/HEAD build/license_extract.sh build/license_defaults
-	@mkdir -p dist/license
-	(cd "lib/$*" && FINDOPTS="$(LIB_LICENSES_FINDOPT_$*)" \
-	 ../../build/license_extract.sh ../../build/license_defaults "$*"  .) > $@
-
-dist/license/subtitlesoctopus: .git/HEAD build/license_extract.sh
-	@mkdir -p dist/license
-	build/license_extract.sh build/license_defaults subtitlesoctopus src > dist/license/subtitlesoctopus
-
-dist/license/all: dist/license/subtitlesoctopus $(addprefix dist/license/, $(LIB_LICENSES)) build/license_fullnotice build/license_lint.awk
-	@echo "# The following lists all copyright notices and licenses for the" >  dist/license/all
-	@echo "# work contained in JavascriptSubtitlesOctopus per project."      >> dist/license/all
-	@echo "" >> dist/license/all
-
-	@echo "Concatenate extracted license info..."
-	@$(foreach LIB_PROJ, subtitlesoctopus $(LIB_LICENSES), \
-		echo "# Project: $(LIB_PROJ)"  >> dist/license/all && \
-		cat  dist/license/$(LIB_PROJ)  >> dist/license/all && \
-	) :
-
-	mv dist/license/all dist/license/all.tmp
-	build/license_lint.awk dist/license/all.tmp build/license_fullnotice
-	cat dist/license/all.tmp build/license_fullnotice > dist/license/all
+dist/license/all:
+	@#FIXME: allow -j in toplevel Makefile and reintegrate licence extraction into this file
+	make -j "$$(nproc)" -f Makefile_licence all
 
 dist/js/COPYRIGHT: dist/license/all
 	cp "$<" "$@"

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,8 @@ DIST_DIR:=$(BASE_DIR)dist/libraries
 GLOBAL_CFLAGS:=-O3 -s USE_PTHREADS=0
 GLOBAL_LDFLAGS:=-s ENVIRONMENT=web,webview,worker -s NO_EXIT_RUNTIME=1
 export LDFLAGS = $(GLOBAL_LDFLAGS)
+export CFLAGS = $(GLOBAL_CFLAGS)
+export CXXFLAGS = $(GLOBAL_CFLAGS)
 
 export PKG_CONFIG_PATH = $(DIST_DIR)/lib/pkgconfig
 export EM_PKG_CONFIG_PATH = $(PKG_CONFIG_PATH)
@@ -26,9 +28,6 @@ build/lib/fribidi/configure: lib/fribidi $(wildcard $(BASE_DIR)build/patches/fri
 $(DIST_DIR)/lib/libfribidi.a: build/lib/fribidi/configure
 	cd build/lib/fribidi && \
 	emconfigure ./configure \
-		CFLAGS=" \
-		$(GLOBAL_CFLAGS) \
-		" \
 		--prefix="$(DIST_DIR)" \
 		--host=x86-none-linux \
 		--build=x86_64 \
@@ -47,9 +46,6 @@ build/lib/expat/configured: lib/expat
 $(DIST_DIR)/lib/libexpat.a: build/lib/expat/configured
 	cd build/lib/expat && \
 	emcmake cmake \
-		-DCMAKE_C_FLAGS=" \
-		$(GLOBAL_CFLAGS) \
-		" \
 		-DCMAKE_INSTALL_PREFIX=$(DIST_DIR) \
 		-DEXPAT_BUILD_DOCS=off \
 		-DEXPAT_SHARED_LIBS=off \
@@ -72,9 +68,6 @@ $(DIST_DIR)/lib/libbrotlidec.a: $(DIST_DIR)/lib/libbrotlicommon.a
 $(DIST_DIR)/lib/libbrotlicommon.a: build/lib/brotli/configured
 	cd build/lib/brotli && \
     emcmake cmake \
-        -DCMAKE_C_FLAGS=" \
-        $(GLOBAL_CFLAGS) \
-        " \
         -DCMAKE_INSTALL_PREFIX=$(DIST_DIR) \
         . \
     && \
@@ -95,9 +88,6 @@ build/lib/freetype/build_hb/dist_hb/lib/libfreetype.a: $(DIST_DIR)/lib/libbrotli
 		mkdir -p build_hb && \
 		cd build_hb && \
 		emconfigure ../configure \
-			CFLAGS=" \
-			$(GLOBAL_CFLAGS) \
-			" \
 			--prefix="$$(pwd)/dist_hb" \
 			--host=x86-none-linux \
 			--build=x86_64 \
@@ -118,15 +108,9 @@ build/lib/harfbuzz/configure: lib/harfbuzz $(wildcard $(BASE_DIR)build/patches/h
 $(DIST_DIR)/lib/libharfbuzz.a: build/lib/freetype/build_hb/dist_hb/lib/libfreetype.a build/lib/harfbuzz/configure
 	cd build/lib/harfbuzz && \
 	EM_PKG_CONFIG_PATH=$(PKG_CONFIG_PATH):$(BASE_DIR)build/lib/freetype/build_hb/dist_hb/lib/pkgconfig \
+	CFLAGS="-DHB_NO_MT $(CFLAGS)" \
+	CXXFLAGS="-DHB_NO_MT $(CFLAGS)" \
 	emconfigure ./configure \
-		CFLAGS=" \
-		$(GLOBAL_CFLAGS) \
-		-DHB_NO_MT \
-		" \
-		CXXFLAGS=" \
-		$(GLOBAL_CFLAGS) \
-		-DHB_NO_MT \
-		" \
 		--prefix="$(DIST_DIR)" \
 		--host=x86-none-linux \
 		--build=x86_64 \
@@ -144,9 +128,6 @@ $(DIST_DIR)/lib/libfreetype.a: $(DIST_DIR)/lib/libharfbuzz.a $(DIST_DIR)/lib/lib
 	cd build/lib/freetype && \
 	EM_PKG_CONFIG_PATH=$(PKG_CONFIG_PATH):$(BASE_DIR)build/lib/freetype/build_hb/dist_hb/lib/pkgconfig \
 	emconfigure ./configure \
-		CFLAGS=" \
-		$(GLOBAL_CFLAGS) \
-		" \
 		--prefix="$(DIST_DIR)" \
 		--host=x86-none-linux \
 		--build=x86_64 \
@@ -167,9 +148,6 @@ build/lib/fontconfig/configure: lib/fontconfig $(wildcard $(BASE_DIR)build/patch
 $(DIST_DIR)/lib/libfontconfig.a: $(DIST_DIR)/lib/libharfbuzz.a $(DIST_DIR)/lib/libexpat.a $(DIST_DIR)/lib/libfribidi.a $(DIST_DIR)/lib/libfreetype.a build/lib/fontconfig/configure
 	cd build/lib/fontconfig && \
 	emconfigure ./configure \
-		CFLAGS=" \
-		$(GLOBAL_CFLAGS) \
-		" \
 		--prefix="$(DIST_DIR)" \
 		--host=x86-none-linux \
 		--build=x86_64 \
@@ -192,9 +170,6 @@ build/lib/libass/configured: lib/libass
 $(DIST_DIR)/lib/libass.a: $(DIST_DIR)/lib/libfontconfig.a $(DIST_DIR)/lib/libharfbuzz.a $(DIST_DIR)/lib/libexpat.a $(DIST_DIR)/lib/libfribidi.a $(DIST_DIR)/lib/libfreetype.a $(DIST_DIR)/lib/libbrotlidec.a build/lib/libass/configured
 	cd build/lib/libass && \
 	emconfigure ../../../lib/libass/configure \
-		CFLAGS=" \
-		$(GLOBAL_CFLAGS) \
-		" \
 		--prefix="$(DIST_DIR)" \
 		--host=x86-none-linux \
 		--build=x86_64 \

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,9 @@ GLOBAL_CFLAGS:=-O3 -s USE_PTHREADS=0
 GLOBAL_LDFLAGS:=-s ENVIRONMENT=web,webview,worker -s NO_EXIT_RUNTIME=1
 export LDFLAGS = $(GLOBAL_LDFLAGS)
 
+export PKG_CONFIG_PATH = $(DIST_DIR)/lib/pkgconfig
+export EM_PKG_CONFIG_PATH = $(PKG_CONFIG_PATH)
+
 all: subtitleoctopus
 subtitleoctopus: dist
 
@@ -91,7 +94,6 @@ build/lib/freetype/build_hb/dist_hb/lib/libfreetype.a: $(DIST_DIR)/lib/libbrotli
 	cd build/lib/freetype && \
 		mkdir -p build_hb && \
 		cd build_hb && \
-		EM_PKG_CONFIG_PATH=$(DIST_DIR)/lib/pkgconfig \
 		emconfigure ../configure \
 			CFLAGS=" \
 			$(GLOBAL_CFLAGS) \
@@ -118,7 +120,7 @@ build/lib/harfbuzz/configure: lib/harfbuzz $(wildcard $(BASE_DIR)build/patches/h
 
 $(DIST_DIR)/lib/libharfbuzz.a: build/lib/freetype/build_hb/dist_hb/lib/libfreetype.a build/lib/harfbuzz/configure
 	cd build/lib/harfbuzz && \
-	EM_PKG_CONFIG_PATH=$(DIST_DIR)/lib/pkgconfig:$(BASE_DIR)build/lib/freetype/build_hb/dist_hb/lib/pkgconfig \
+	EM_PKG_CONFIG_PATH=$(PKG_CONFIG_PATH):$(BASE_DIR)build/lib/freetype/build_hb/dist_hb/lib/pkgconfig \
 	emconfigure ./configure \
 		CFLAGS=" \
 		$(GLOBAL_CFLAGS) \
@@ -147,7 +149,7 @@ $(DIST_DIR)/lib/libharfbuzz.a: build/lib/freetype/build_hb/dist_hb/lib/libfreety
 # Freetype with Harfbuzz
 $(DIST_DIR)/lib/libfreetype.a: $(DIST_DIR)/lib/libharfbuzz.a $(DIST_DIR)/lib/libbrotlidec.a
 	cd build/lib/freetype && \
-	EM_PKG_CONFIG_PATH=$(DIST_DIR)/lib/pkgconfig:$(BASE_DIR)build/lib/freetype/build_hb/dist_hb/lib/pkgconfig \
+	EM_PKG_CONFIG_PATH=$(PKG_CONFIG_PATH):$(BASE_DIR)build/lib/freetype/build_hb/dist_hb/lib/pkgconfig \
 	emconfigure ./configure \
 		CFLAGS=" \
 		$(GLOBAL_CFLAGS) \
@@ -174,7 +176,6 @@ build/lib/fontconfig/configure: lib/fontconfig $(wildcard $(BASE_DIR)build/patch
 
 $(DIST_DIR)/lib/libfontconfig.a: $(DIST_DIR)/lib/libharfbuzz.a $(DIST_DIR)/lib/libexpat.a $(DIST_DIR)/lib/libfribidi.a $(DIST_DIR)/lib/libfreetype.a build/lib/fontconfig/configure
 	cd build/lib/fontconfig && \
-	EM_PKG_CONFIG_PATH=$(DIST_DIR)/lib/pkgconfig \
 	emconfigure ./configure \
 		CFLAGS=" \
 		$(GLOBAL_CFLAGS) \
@@ -200,7 +201,6 @@ build/lib/libass/configured: lib/libass
 
 $(DIST_DIR)/lib/libass.a: $(DIST_DIR)/lib/libfontconfig.a $(DIST_DIR)/lib/libharfbuzz.a $(DIST_DIR)/lib/libexpat.a $(DIST_DIR)/lib/libfribidi.a $(DIST_DIR)/lib/libfreetype.a $(DIST_DIR)/lib/libbrotlidec.a build/lib/libass/configured
 	cd build/lib/libass && \
-	EM_PKG_CONFIG_PATH=$(DIST_DIR)/lib/pkgconfig \
 	emconfigure ../../../lib/libass/configure \
 		CFLAGS=" \
 		$(GLOBAL_CFLAGS) \
@@ -232,7 +232,6 @@ OCTP_DEPS = \
 src/subtitles-octopus-worker.bc: $(OCTP_DEPS) all-src
 .PHONY: all-src
 all-src:
-	PKG_CONFIG_PATH=$(DIST_DIR)/lib/pkgconfig \
 	$(MAKE) -C src all
 
 # Dist Files

--- a/Makefile
+++ b/Makefile
@@ -365,6 +365,6 @@ server: # Node http server npm i -g http-server
 
 
 SUBMODULES := brotli expat fontconfig freetype fribidi harfbuzz libass
-git-update: $(addprefix git-, $(SUBMODULES))
+git-smreset: $(addprefix git-, $(SUBMODULES))
 
-$(foreach subm, $(SUBMODULES), $(eval $(call TR_GIT_SM_UPDATE,$(subm))))
+$(foreach subm, $(SUBMODULES), $(eval $(call TR_GIT_SM_RESET,$(subm))))

--- a/Makefile_licence
+++ b/Makefile_licence
@@ -1,0 +1,39 @@
+# FIXME: temporarily split Makefile to parallelise licence info extraction
+#        once -j can be passed to the toplevel Makefile this should be moved
+#        back into the main Makefile
+
+all: dist/license/all
+
+LIB_LICENSES := brotli expat freetype fribidi fontconfig harfbuzz libass
+LIB_LICENSES_FINDOPT_brotli   := -path ./research -prune -false -o ! -path ./js/decode.min.js
+LIB_LICENSES_FINDOPT_expat    := -path ./expat/fuzz -prune -false -o
+LIB_LICENSES_FINDOPT_freetype := -path ./src/tools -prune -false -o
+LIB_LICENSES_FINDOPT_fribidi  := -path ./bin -prune -false -o
+LIB_LICENSES_FINDOPT_harfbuzz := -path ./test -prune -false -o
+
+$(addprefix dist/license/, $(LIB_LICENSES)): dist/license/%: .git/modules/lib/%/HEAD build/license_extract.sh build/license_defaults
+	@mkdir -p dist/license
+	(cd "lib/$*" && FINDOPTS="$(LIB_LICENSES_FINDOPT_$*)" \
+	 ../../build/license_extract.sh ../../build/license_defaults "$*"  .) > $@
+
+dist/license/subtitlesoctopus: .git/HEAD build/license_extract.sh
+	@mkdir -p dist/license
+	build/license_extract.sh build/license_defaults subtitlesoctopus src > dist/license/subtitlesoctopus
+
+dist/license/all: dist/license/subtitlesoctopus $(addprefix dist/license/, $(LIB_LICENSES)) build/license_fullnotice build/license_lint.awk
+	@echo "# The following lists all copyright notices and licenses for the" >  dist/license/all
+	@echo "# work contained in JavascriptSubtitlesOctopus per project."      >> dist/license/all
+	@echo "" >> dist/license/all
+
+	@echo "Concatenate extracted license info..."
+	@$(foreach LIB_PROJ, subtitlesoctopus $(LIB_LICENSES), \
+		echo "# Project: $(LIB_PROJ)"  >> dist/license/all && \
+		cat  dist/license/$(LIB_PROJ)  >> dist/license/all && \
+	) :
+
+	mv dist/license/all dist/license/all.tmp
+	build/license_lint.awk dist/license/all.tmp build/license_fullnotice
+	cat dist/license/all.tmp build/license_fullnotice > dist/license/all
+
+dist/js/COPYRIGHT: dist/license/all
+	cp "$<" "$@"

--- a/build/patches/brotli/0002-upstream_Enable-install-with-emscripten.patch
+++ b/build/patches/brotli/0002-upstream_Enable-install-with-emscripten.patch
@@ -1,0 +1,71 @@
+Backported from: https://github.com/google/brotli/commit/ce222e317e36aa362e83fc50c7a6226d238e03fd
+From: Dirk Lemstra <dirk@lemstra.org>
+Date: Wed, 23 Jun 2021 10:12:21 +0200
+Subject: [PATCH] Enabled install when building with emscripten. (#906)
+
+* Enabled install when building with emscripten.
+
+* Also install the pkg-config files.
+---
+ CMakeLists.txt | 18 ++++++++----------
+ 1 file changed, 8 insertions(+), 10 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 4ff3401..6999292 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -219,19 +219,20 @@ add_executable(brotli ${BROTLI_CLI_C})
+ target_link_libraries(brotli ${BROTLI_LIBRARIES_STATIC})
+ 
+ # Installation
+-if(NOT BROTLI_EMSCRIPTEN)
+ if(NOT BROTLI_BUNDLED_MODE)
+   install(
+     TARGETS brotli
+     RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
+   )
+ 
+-  install(
+-    TARGETS ${BROTLI_LIBRARIES_CORE}
+-    ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+-    LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+-    RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
+-  )
++  if(NOT BROTLI_EMSCRIPTEN)
++    install(
++      TARGETS ${BROTLI_LIBRARIES_CORE}
++      ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
++      LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
++      RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
++    )
++  endif()  # BROTLI_EMSCRIPTEN
+ 
+   install(
+     TARGETS ${BROTLI_LIBRARIES_CORE_STATIC}
+@@ -245,7 +246,6 @@ if(NOT BROTLI_BUNDLED_MODE)
+     DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
+   )
+ endif()  # BROTLI_BUNDLED_MODE
+-endif()  # BROTLI_EMSCRIPTEN
+ 
+ # Tests
+ 
+@@ -405,7 +405,6 @@ transform_pc_file("scripts/libbrotlidec.pc.in" "${CMAKE_CURRENT_BINARY_DIR}/libb
+ 
+ transform_pc_file("scripts/libbrotlienc.pc.in" "${CMAKE_CURRENT_BINARY_DIR}/libbrotlienc.pc" "${BROTLI_VERSION}")
+ 
+-if(NOT BROTLI_EMSCRIPTEN)
+ if(NOT BROTLI_BUNDLED_MODE)
+   install(FILES "${CMAKE_CURRENT_BINARY_DIR}/libbrotlicommon.pc"
+     DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
+@@ -414,7 +413,6 @@ if(NOT BROTLI_BUNDLED_MODE)
+   install(FILES "${CMAKE_CURRENT_BINARY_DIR}/libbrotlienc.pc"
+     DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
+ endif()  # BROTLI_BUNDLED_MODE
+-endif()  # BROTLI_EMSCRIPTEN
+ 
+ if (ENABLE_COVERAGE STREQUAL "yes")
+   SETUP_TARGET_FOR_COVERAGE(coverage test coverage)
+-- 
+2.30.2
+

--- a/functions.mk
+++ b/functions.mk
@@ -27,6 +27,22 @@ endef
 # All projects we build have autogen.sh, otherwise we could also fallback to `autoreconf -ivf .`
 RECONF_AUTO := NOCONFIGURE=1 ./autogen.sh
 
+# @arg1: path to source directory; defaults to current working directory
+define CONFIGURE_AUTO
+	emconfigure $(or $(1),.)/configure \
+	  --prefix="$(DIST_DIR)" \
+	  --host=x86-none-linux \
+	  --build=x86_64 \
+	  --enable-static \
+	  --disable-shared \
+	  --disable-debug
+endef
+
+# @arg1: path to source directory; defaults to current working directory
+define CONFIGURE_CMAKE
+	emcmake cmake -S "$(or $(1),.)" -DCMAKE_INSTALL_PREFIX="$(DIST_DIR)"
+endef
+
 
 ## Clean and git related
 

--- a/functions.mk
+++ b/functions.mk
@@ -43,6 +43,8 @@ define CONFIGURE_CMAKE
 	emcmake cmake -S "$(or $(1),.)" -DCMAKE_INSTALL_PREFIX="$(DIST_DIR)"
 endef
 
+# FIXME: Propagate jobserver info with $(MAKE) and set up our makefile for fully parallel builds
+JSO_MAKE := emmake make -j "$(shell nproc)"
 
 ## Clean and git related
 

--- a/functions.mk
+++ b/functions.mk
@@ -15,4 +15,6 @@ git-$(1):
 	git reset --hard && \
 	git clean -dfx
 	git submodule update --force lib/$(1)
+
+.PHONY: git-$(1)
 endef

--- a/functions.mk
+++ b/functions.mk
@@ -1,0 +1,18 @@
+# For inclusion in toplevel Makefile
+#   Defines some useful macros and variables for building etc
+#   If arguments are expected (macro) it needs to be invoked with $(call ...),
+#   if no arguments are supported the definition is aregular avariable and can be used as such.
+#   Special macros of the name TR_... create targets (and always take arguments)
+#   and thus also need to be $(eval ...)'ed
+
+
+## Clean and git related
+
+# @arg1: submodule name
+define TR_GIT_SM_UPDATE
+git-$(1):
+	cd lib/$(1) && \
+	git reset --hard && \
+	git clean -dfx && \
+	git pull origin master
+endef

--- a/functions.mk
+++ b/functions.mk
@@ -9,10 +9,10 @@
 ## Clean and git related
 
 # @arg1: submodule name
-define TR_GIT_SM_UPDATE
+define TR_GIT_SM_RESET
 git-$(1):
 	cd lib/$(1) && \
 	git reset --hard && \
-	git clean -dfx && \
-	git pull origin master
+	git clean -dfx
+	git submodule update --force lib/$(1)
 endef

--- a/functions.mk
+++ b/functions.mk
@@ -5,6 +5,28 @@
 #   Special macros of the name TR_... create targets (and always take arguments)
 #   and thus also need to be $(eval ...)'ed
 
+## Build stuff
+
+# @arg1: name of submodule
+define PREPARE_SRC_PATCHED
+	rm -rf build/lib/$(1)
+	mkdir -p build/lib
+	cp -r lib/$(1) build/lib/$(1)
+	$(foreach file, $(wildcard $(BASE_DIR)build/patches/$(1)/*.patch), \
+		patch -d "$(BASE_DIR)build/lib/$(1)" -Np1 -i $(file) && \
+	) :
+endef
+
+# @arg1: name of submdolue
+define PREPARE_SRC_VPATH
+	rm -rf build/lib/$(1)
+	mkdir -p build/lib/$(1)
+	touch build/lib/$(1)/configured
+endef
+
+# All projects we build have autogen.sh, otherwise we could also fallback to `autoreconf -ivf .`
+RECONF_AUTO := NOCONFIGURE=1 ./autogen.sh
+
 
 ## Clean and git related
 


### PR DESCRIPTION
Follow up to the “patch cleanup” series and comments in #129.
    
From previous discussion:
  - Change to a submodule reset instead of update to master (supersedes 0ef4dc5fdb842f86fc6edfa6b2f604f5e045113a from #129)
  - Mark non-file targets as `.PHONY`
  - Macroise all the repeated setup and configure bits
  - Move more flags to global scope if appropiate
  - Remove unnecessary flags

**Additionally** this also simplifies the brotli build by backporting one commit from upstream (not yet found in a release) and as an intermediate measure to improve buildtimes until the Makefile can properly handle intra-target parallelism we now use “number of logical cores” for each build and the license extraction is split off into a separate file called running multiple jobs in parallel.  

Judging from the runs so far this reduces the GHA times *(2 logical cores available)* from previously 21-18 minutes to now 15-13 minutes.