### PR TITLE
Enable strict mode in js

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 BASE_DIR:=$(dir $(realpath $(firstword $(MAKEFILE_LIST))))
 DIST_DIR:=$(BASE_DIR)dist/libraries
 
-export LDFLAGS = -O3 -s ENVIRONMENT=web,webview,worker -s NO_EXIT_RUNTIME=1
+export LDFLAGS = -O3 -s ENVIRONMENT=web,webview,worker -s NO_EXIT_RUNTIME=1 -s STRICT_JS=1
 export CFLAGS = -O3 -s USE_PTHREADS=0
 export CXXFLAGS = $(CFLAGS)
 export PKG_CONFIG_PATH = $(DIST_DIR)/lib/pkgconfig

--- a/src/subtitles-octopus.js
+++ b/src/subtitles-octopus.js
@@ -1,3 +1,4 @@
+"use strict";
 var SubtitlesOctopus = function (options) {
     var supportsWebAssembly = false;
     try {


### PR DESCRIPTION
In my crude and limited tests, I didn't see any relevant performance difference not within run-to-run variance (i.e. also no degradation), but I'm not familiar with benchmarking js.
@ThaUnknown: would you like to take a look and see, if this has a negative, positive or no performance impact?