### PR TITLE
Ignore all files for Docker build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+# Ignore everything for build image step, /code is passed via a volume
+*


### PR DESCRIPTION
Every time a build without `$FAST`, `$ docker build` is invoked.
While the Dockerfile does not require any files from the local context, the current directory is loaded as part of the build process.

Before:
```
$ ./run-docker-build.sh
Sending build context to Docker daemon  604.9MB
...
```

After:
```
$ ./run-docker-build.sh
Sending build context to Docker daemon  3.072kB
...
```