### PR TITLE
Enable LTO, EVAL_CTOR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -154,6 +154,7 @@ all-src:
 # Dist Files
 EMCC_COMMON_ARGS = \
 	$(LDFLAGS) \
+	-s AUTO_NATIVE_LIBRARIES=0 \
 	-s EXPORTED_FUNCTIONS="['_main', '_malloc']" \
 	-s EXPORTED_RUNTIME_METHODS="['ccall', 'cwrap', 'getValue', 'FS_createPreloadedFile', 'FS_createPath']" \
 	--use-preload-plugins \

--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,8 @@
 BASE_DIR:=$(dir $(realpath $(firstword $(MAKEFILE_LIST))))
 DIST_DIR:=$(BASE_DIR)dist/libraries
 
-export LDFLAGS = -O3 -s ENVIRONMENT=web,webview,worker -s NO_EXIT_RUNTIME=1 -s STRICT_JS=1
-export CFLAGS = -O3 -s USE_PTHREADS=0
+export LDFLAGS = -O3 -s EVAL_CTORS=1 -flto -s ENVIRONMENT=web,webview,worker -s NO_EXIT_RUNTIME=1 -s STRICT_JS=1
+export CFLAGS = -O3 -flto -s USE_PTHREADS=0
 export CXXFLAGS = $(CFLAGS)
 export PKG_CONFIG_PATH = $(DIST_DIR)/lib/pkgconfig
 export EM_PKG_CONFIG_PATH = $(PKG_CONFIG_PATH)


### PR DESCRIPTION
These changes enable LTO for the build process, and decreases the number of files (data / mem files). While this increases total size slightly, it reduces the number of files fetched from network overall. This is further lowered down in a future PR where the fallback font is extracted from the binaries.

The output of the dist folder now looks like this:
```
-rw-r--r-- 1 root root  46K jun 22 10:22 COPYRIGHT
-rw-r--r-- 1 root root  74K jun 22 10:22 subtitles-octopus.js
-rw-r--r-- 1 root root 584K jun 22 10:16 subtitles-octopus-worker.js
-rw-r--r-- 1 root root 4,7M jun 22 10:17 subtitles-octopus-worker-legacy.js
-rwxr-xr-x 1 root root 2,2M jun 22 10:16 subtitles-octopus-worker.wasm
```

EDIT: changes regarding number of files are being moved to #146 