### PR TITLE
Implement lazy font loading, enable embedded font extraction

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -156,16 +156,16 @@ EMCC_COMMON_ARGS = \
 	$(LDFLAGS) \
 	-s AUTO_NATIVE_LIBRARIES=0 \
 	-s EXPORTED_FUNCTIONS="['_main', '_malloc']" \
+	-s DEFAULT_LIBRARY_FUNCS_TO_INCLUDE="['\$$Browser']" \
 	-s EXPORTED_RUNTIME_METHODS="['ccall', 'cwrap', 'getValue', 'FS_createPreloadedFile', 'FS_createPath']" \
-	--use-preload-plugins \
-	--preload-file assets/default.woff2 \
-	--preload-file assets/fonts.conf \
+	--embed-file assets/fonts.conf \
 	-s ALLOW_MEMORY_GROWTH=1 \
 	-s NO_FILESYSTEM=0 \
+	--memory-init-file=0 \
 	--no-heap-copy \
 	-o $@
 
-dist: src/subtitles-octopus-worker.bc dist/js/subtitles-octopus-worker.js dist/js/subtitles-octopus-worker-legacy.js dist/js/subtitles-octopus.js dist/js/COPYRIGHT
+dist: src/subtitles-octopus-worker.bc dist/js/subtitles-octopus-worker.js dist/js/subtitles-octopus-worker-legacy.js dist/js/subtitles-octopus.js dist/js/COPYRIGHT dist/js/default.woff2
 
 dist/js/subtitles-octopus-worker.js: src/subtitles-octopus-worker.bc src/pre-worker.js src/SubOctpInterface.js src/post-worker.js build/lib/brotli/js/decode.js
 	mkdir -p dist/js
@@ -204,6 +204,9 @@ dist/license/all:
 
 dist/js/COPYRIGHT: dist/license/all
 	cp "$<" "$@"
+
+dist/js/default.woff2:
+	cp assets/default.woff2 "$@"
 
 # Clean Tasks
 

--- a/README.md
+++ b/README.md
@@ -114,6 +114,8 @@ When creating an instance of SubtitleOctopus, you can set the following options:
 - `fonts`: An array of links to the fonts used in the subtitle. (Optional)
 - `availableFonts`: Object with all available fonts - Key is font name in lower
   case, value is link: `{"arial": "/font1.ttf"}` (Optional)
+- `fallbackFont`: URL to override fallback font, for example, with a CJK one. Default fallback font is Liberation Sans (Optional)
+- `lazyFileLoading`: A boolean, whether to load files in a lazy way via [FS.createLazyFile()](https://emscripten.org/docs/api_reference/Filesystem-API.html#FS.createLazyFile). [Requires](https://github.com/emscripten-core/emscripten/blob/c7b21c32fef92799da05d15ba1939b6394fe0373/src/library_fs.js#L1679-L1856) `Access-Control-Expose-Headers` for `Accept-Ranges, Content-Length, and Content-Encoding`. If encoding is compressed or length is not set, file will be fully fetched instead of just a HEAD request.
 - `timeOffset`: The amount of time the subtitles should be offset from the
   video. (Default: `0`)
 - `onReady`: Function that's called when SubtitlesOctopus is ready. (Optional)

--- a/src/SubtitleOctopus.cpp
+++ b/src/SubtitleOctopus.cpp
@@ -6,6 +6,7 @@
 #include <stdlib.h>
 #include <stdarg.h>
 #include <string.h>
+#include <string>
 #include <cstdint>
 #include <ass/ass.h>
 
@@ -247,6 +248,8 @@ public:
 
     int status;
 
+    std::string defaultFont;
+
     SubtitleOctopus() {
         status = 0;
         ass_library = NULL;
@@ -281,7 +284,11 @@ public:
         scanned_events = i;
     }
 
-    void initLibrary(int frame_w, int frame_h) {
+    void initLibrary(int frame_w, int frame_h, char* default_font) {
+        if (default_font != NULL) {
+            defaultFont.assign(default_font);
+        }
+
         ass_library = ass_library_init();
         if (!ass_library) {
             fprintf(stderr, "jso: ass_library_init failed!\n");
@@ -353,11 +360,11 @@ public:
     void reloadLibrary() {
         quitLibrary();
 
-        initLibrary(canvas_w, canvas_h);
+        initLibrary(canvas_w, canvas_h, NULL);
     }
 
     void reloadFonts() {
-        ass_set_fonts(ass_renderer, "/assets/default.woff2", NULL, ASS_FONTPROVIDER_FONTCONFIG, "/assets/fonts.conf", 1);
+        ass_set_fonts(ass_renderer, defaultFont.c_str(), NULL, ASS_FONTPROVIDER_FONTCONFIG, "/assets/fonts.conf", 1);
     }
 
     void setMargin(int top, int bottom, int left, int right) {

--- a/src/SubtitleOctopus.idl
+++ b/src/SubtitleOctopus.idl
@@ -172,7 +172,7 @@ interface SubtitleOctopus {
     attribute ASS_Library ass_library;
     void setLogLevel(long level);
     void setDropAnimations(long value);
-    void initLibrary(long frame_w, long frame_h);
+    void initLibrary(long frame_w, long frame_h, DOMString default_font);
     void createTrack(DOMString subfile);
     void createTrackMem(DOMString buf, unsigned long bufsize);
     void removeTrack();

--- a/src/pre-worker.js
+++ b/src/pre-worker.js
@@ -94,10 +94,12 @@ Module["preRun"].push(function () {
 
     self.subContent = null;
 
+    self.loadFontFile(".fallback-", self.fallbackFont);
+
     //Module["FS"].mount(Module["FS"].filesystems.IDBFS, {}, '/fonts');
     var fontFiles = self.fontFiles || [];
     for (var i = 0; i < fontFiles.length; i++) {
-        Module["FS_createPreloadedFile"]("/fonts", 'font' + i + '-' + fontFiles[i].split('/').pop(), fontFiles[i], true, true);
+        self.loadFontFile('font' + i + '-', fontFiles[i]);
     }
 });
 
@@ -111,7 +113,7 @@ Module['onRuntimeInitialized'] = function () {
     self.blendW = Module._malloc(4);
     self.blendH = Module._malloc(4);
 
-    self.octObj.initLibrary(screen.width, screen.height);
+    self.octObj.initLibrary(screen.width, screen.height, "/fonts/.fallback-" + self.fallbackFont.split('/').pop());
     self.octObj.setDropAnimations(self.dropAllAnimations);
     self.octObj.createTrack("/sub.ass");
     self.ass_track = self.octObj.track;

--- a/src/subtitles-octopus.js
+++ b/src/subtitles-octopus.js
@@ -27,6 +27,8 @@ var SubtitlesOctopus = function (options) {
     self.canvasParent = null; // (internal) HTML canvas parent element
     self.fonts = options.fonts || []; // Array with links to fonts used in sub (optional)
     self.availableFonts = options.availableFonts || []; // Object with all available fonts (optional). Key is font name in lower case, value is link: {"arial": "/font1.ttf"}
+    self.fallbackFont = options.fallbackFont || 'default.woff2'; // URL to override fallback font, for example, with a CJK one. Default fallback font is Liberation Sans (Optional)
+    self.lazyFileLoading = options.lazyFileLoading || false; // Load fonts in a lazy way. Requires Access-Control-Expose-Headers for Accept-Ranges, Content-Length, and Content-Encoding. If Content-Encoding is compressed, file will be fully fetched instead of just a HEAD request.
     self.onReadyEvent = options.onReady; // Function called when SubtitlesOctopus is ready (optional)
     if (supportsWebAssembly) {
         self.workerUrl = options.workerUrl || 'subtitles-octopus-worker.js'; // Link to WebAssembly worker
@@ -112,6 +114,8 @@ var SubtitlesOctopus = function (options) {
             subContent: self.subContent,
             fonts: self.fonts,
             availableFonts: self.availableFonts,
+            fallbackFont: self.fallbackFont,
+            lazyFileLoading: self.lazyFileLoading,
             debug: self.debug,
             targetFps: self.targetFps,
             libassMemoryLimit: self.libassMemoryLimit,


### PR DESCRIPTION
Contains one commit (7a69b7fcdee7b66f698ec032d4bc42abe86d85fe) from #145.

These changes extract the embedded font, and add the option to enable lazy font loading (where font resources are mapped, but not downloaded until libass tries to use them).

Additionally, `fallbackFont` option can be used to override the default fallback font that gets used. This way, users can specify their preferred font, including CJK ones (for example Noto Sans CJK .ttc).

Enabling lazy font loading is done via `lazyFontLoading` set to `true`, but it defaults to `false`.
This is necessary given some requirements from WASM to not fetch the whole file, specifically:
* HEAD and Range request support
* `Access-Control-Expose-Headers: Accept-Ranges, Content-Length, Content-Encoding` (at least)
* No Content-Encoding set.
If these conditions match, HEAD request will be issued and file will be accessed via Ranges as-needed. Otherwise content will be fetched as a whole file.

Additionally, this PR enables embedded font extraction support on libass side. This is split on a separate commit.
