### PR TITLE
feat: Add optional skipAspectRatioCheck

### DIFF
--- a/src/subtitles-octopus.js
+++ b/src/subtitles-octopus.js
@@ -245,9 +245,10 @@ var SubtitlesOctopus = function (options) {
         var width = self.video.offsetWidth, height = self.video.offsetHeight;
         var elementRatio = width / height;
         var realWidth = width, realHeight = height;
-        if (elementRatio > videoRatio) realWidth = Math.floor(height * videoRatio);
-        else realHeight = Math.floor(width / videoRatio);
-
+        if(!options.skipAspectRatioCheck) {
+            if (elementRatio > videoRatio) realWidth = Math.floor(height * videoRatio);
+            else realHeight = Math.floor(width / videoRatio);
+        }
         var x = (width - realWidth) / 2;
         var y = (height - realHeight) / 2;
 


### PR DESCRIPTION
In my project, I need to make a manual crop for video.
For example - I make a horizontal crop(16/9) for a video with a vertical landscape(9/16) with scaling it.

Actual result:
![image](https://github.com/libass/JavascriptSubtitlesOctopus/assets/135326716/47262f30-4e21-4ae3-9e40-f3853bc99bc1)
This happens because the subtitles octopus checks the original video aspect ratio and gets the width according to this value.
`    self.getVideoPosition = function () {
        var videoRatio = self.video.videoWidth / self.video.videoHeight;
        var width = self.video.offsetWidth, height = self.video.offsetHeight;
        var elementRatio = width / height;
        var realWidth = width, realHeight = height;
        if (elementRatio > videoRatio) realWidth = Math.floor(height * videoRatio);
        else realHeight = Math.floor(width / videoRatio);
        ....
   }`

Expected result:
![image](https://github.com/libass/JavascriptSubtitlesOctopus/assets/135326716/b6ddfabb-454c-41bf-95fd-f55864e206c3)


I understand that my case is non-standard, so I allowed to hide standard behavior by optional prop